### PR TITLE
Android.mk: Disable prelinking by default

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,6 +6,7 @@ LOCAL_SRC_FILES:= mixer.c pcm.c
 LOCAL_MODULE := libtinyalsa
 LOCAL_SHARED_LIBRARIES:= libcutils libutils
 LOCAL_MODULE_TAGS := optional
+LOCAL_PRELINK_MODULE := false
 
 include $(BUILD_SHARED_LIBRARY)
 


### PR DESCRIPTION
Support building out of the box on Android releases that don't have this
library in their prelink map.
