### PR TITLE
pcm: Constify pcm_write() buffer

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -120,7 +120,7 @@ int pcm_get_htimestamp(struct pcm *pcm, unsigned int *avail,
  * Will start playback on the first write or on a write that
  * occurs after a fifo underrun.
  */
-int pcm_write(struct pcm *pcm, void *data, unsigned int count);
+int pcm_write(struct pcm *pcm, const void *data, unsigned int count);
 int pcm_read(struct pcm *pcm, void *data, unsigned int count);
 
 /* Start and stop a PCM channel that doesn't transfer data */

--- a/pcm.c
+++ b/pcm.c
@@ -285,14 +285,14 @@ int pcm_get_htimestamp(struct pcm *pcm, unsigned int *avail,
     return 0;
 }
 
-int pcm_write(struct pcm *pcm, void *data, unsigned int count)
+int pcm_write(struct pcm *pcm, const void *data, unsigned int count)
 {
     struct snd_xferi x;
 
     if (pcm->flags & PCM_IN)
         return -EINVAL;
 
-    x.buf = data;
+    x.buf = (void *)data;
     x.frames = count / (pcm->config.channels *
                         pcm_format_to_bits(pcm->config.format) / 8);
 


### PR DESCRIPTION
Make it easier to use pcm_write() by marking the buffer as const.
