### PR TITLE
pcm: Add pcm_prepare() operation

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -127,6 +127,8 @@ int pcm_read(struct pcm *pcm, void *data, unsigned int count);
 int pcm_start(struct pcm *pcm);
 int pcm_stop(struct pcm *pcm);
 
+/* Configure an off CPU PCM channel (eg, baseband<->CODEC link) */
+int pcm_prepare(struct pcm *pcm);
 
 /*
  * MIXER API

--- a/pcm.c
+++ b/pcm.c
@@ -487,3 +487,11 @@ int pcm_stop(struct pcm *pcm)
     return 0;
 }
 
+int pcm_prepare(struct pcm *pcm)
+{
+    if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_PREPARE) < 0)
+        return oops(pcm, errno, "cannot prepare channel");
+    pcm->running = 1;
+
+    return 0;
+}


### PR DESCRIPTION
Some PCM links, especially baseband<->CODEC links, don't pass through
the CPU at all and have no visible DMA controller but as they use the
same hardware links they get presented to the application layer as PCM
links for configuration.  We can't use _start() on these links as that
will fail due to trying to trigger the DMA controller which isn't
possible as there is no data path into the CPU.

Future kernels will hide this from the application layer but for now
this is what the kernel needs us to do.
