### PR TITLE
tinyplay: Use buffer size in bytes instead of frames

### DIFF
--- a/tinyplay.c
+++ b/tinyplay.c
@@ -155,7 +155,7 @@ void play_sample(FILE *file, unsigned int card, unsigned int device, unsigned in
         return;
     }
 
-    size = pcm_get_buffer_size(pcm);
+    size = pcm_frames_to_bytes(pcm, pcm_get_buffer_size(pcm));
     buffer = malloc(size);
     if (!buffer) {
         fprintf(stderr, "Unable to allocate %d bytes\n", size);


### PR DESCRIPTION
pcm_write expects to receive buffer size given in bytes,
but tinyplay sends as a parameter the size in frames, which
causes audio sample data loss for some scenarios where more
than 2 channels are used.

For example:
When using 6 channels and 1024 as period size:

-On tinyplay side
size=4096 (buffer_size)

-On pcm_write (pcm.c)

x.frames = count / (pcm->config.channels *
                        pcm_format_to_bits(pcm->config.format) / 8);
x.frames = 4096 / (6 \* 16/8)

x.frames = 341.33 (decimal part is discarded, 4 bytes are lost every
##         pcm_write)

In this case, 4 bytes are lost, which causes a shift
of the channels.

Use buffer size in bytes in order to avoid this problem.

Signed-off-by: Axel Castaneda Gonzalez x0055901@ti.com
