### PR TITLE
pcm: Constify write buffers

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -133,13 +133,13 @@ int pcm_get_htimestamp(struct pcm *pcm, unsigned int *avail,
  * Will start playback on the first write or on a write that
  * occurs after a fifo underrun.
  */
-int pcm_write(struct pcm *pcm, void *data, unsigned int count);
+int pcm_write(struct pcm *pcm, const void *data, unsigned int count);
 int pcm_read(struct pcm *pcm, void *data, unsigned int count);
 
 /*
  * mmap() support.
  */
-int pcm_mmap_write(struct pcm *pcm, void *data, unsigned int count);
+int pcm_mmap_write(struct pcm *pcm, const void *data, unsigned int count);
 int pcm_mmap_begin(struct pcm *pcm, void **areas, unsigned int *offset,
                    unsigned int *frames);
 int pcm_mmap_commit(struct pcm *pcm, unsigned int offset, unsigned int frames);

--- a/pcm.c
+++ b/pcm.c
@@ -295,7 +295,7 @@ static int pcm_areas_copy(struct pcm *pcm, unsigned int pcm_offset,
     return 0;
 }
 
-static int pcm_mmap_write_areas(struct pcm *pcm, char *src,
+static int pcm_mmap_write_areas(struct pcm *pcm, const char *src,
                                 unsigned int offset, unsigned int size)
 {
     void *pcm_areas;
@@ -355,14 +355,14 @@ int pcm_get_htimestamp(struct pcm *pcm, unsigned int *avail,
     return 0;
 }
 
-int pcm_write(struct pcm *pcm, void *data, unsigned int count)
+int pcm_write(struct pcm *pcm, const void *data, unsigned int count)
 {
     struct snd_xferi x;
 
     if (pcm->flags & PCM_IN)
         return -EINVAL;
 
-    x.buf = data;
+    x.buf = (void*)data;
     x.frames = count / (pcm->config.channels *
                         pcm_format_to_bits(pcm->config.format) / 8);
 
@@ -748,7 +748,7 @@ int pcm_wait(struct pcm *pcm, int timeout)
     return 1;
 }
 
-int pcm_mmap_write(struct pcm *pcm, void *buffer, unsigned int bytes)
+int pcm_mmap_write(struct pcm *pcm, const void *buffer, unsigned int bytes)
 {
     int err = 0, frames, avail;
     unsigned int offset = 0, count;


### PR DESCRIPTION
Mark the write buffers as const - they won't be modified and this is
friendlier to applications.
