### PR TITLE
pcm: Add function to retrieve alsa audio device properties

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -67,6 +67,10 @@ enum pcm_format {
 
 /* Configuration for a stream */
 struct pcm_config {
+    unsigned int channels_min;
+    unsigned int channels_max;
+    unsigned int rate_max;
+    unsigned int rate_min;
     unsigned int channels;
     unsigned int rate;
     unsigned int period_size;


### PR DESCRIPTION
Utilize the ioctl SNDRV_PCM_IOCTL_HW_REFINE to get device properties
from the kernel and make visible in userspace.
- Provide min and max sample rate and channels
