### PR TITLE
tinycap: Fix byte_rate and block_align values

### DIFF
--- a/tinycap.c
+++ b/tinycap.c
@@ -136,9 +136,9 @@ int main(int argc, char **argv)
     header.audio_format = FORMAT_PCM;
     header.num_channels = channels;
     header.sample_rate = rate;
+    header.bits_per_sample = bits;
     header.byte_rate = (header.bits_per_sample / 8) * channels * rate;
     header.block_align = channels * (header.bits_per_sample / 8);
-    header.bits_per_sample = bits;
     header.data_id = ID_DATA;
 
     /* leave enough room for header */


### PR DESCRIPTION
'byte_rate' and 'block_align' sections of the WAV header were calculated
using an invalid 'bits_per_sample' value. 'bits_per_sample' is now set
before it gets used by other fields.

Signed-off-by: Misael Lopez Cruz misael.lopez@ti.com
