### PR TITLE
add error check for pcm_start in pcm_read

### DIFF
--- a/pcm.c
+++ b/pcm.c
@@ -405,7 +405,10 @@ int pcm_read(struct pcm *pcm, void *data, unsigned int count)
 
     for (;;) {
         if (!pcm->running) {
-            pcm_start(pcm);
+            if (pcm_start(pcm) < 0) {
+                fprintf(stderr, "start error");
+                return -errno;
+            }
         }
         if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_READI_FRAMES, &x)) {
             pcm->running = 0;


### PR DESCRIPTION
- Otherwise, read will be tried even after pcm_start is failed.
  This leads into blocking inside the read ioctl forever.
  pcm_start can fail, for example in full-speed USB audio device,
  in some H/W, due to the lack of bandwidth in USB bus,
