### PR TITLE
Correctly fill the value for riff chunk size in the WAV file produced by tinycap

### DIFF
--- a/tinycap.c
+++ b/tinycap.c
@@ -153,6 +153,7 @@ int main(int argc, char **argv)
 
     /* write header now all information is known */
     header.data_sz = frames * header.block_align;
+    header.riff_sz = header.data_sz + sizeof(header) - 8;
     fseek(file, 0, SEEK_SET);
     fwrite(&header, sizeof(struct wav_header), 1, file);
 


### PR DESCRIPTION
Some audio tools do not recognize wave files that are recorded with tinycap. That is because RIFF format requires the chunk size to be set correctly. So far we have been leaving that field as 0. In this commit I am filling it with the right value, which is "the length of the file till the end from this point", or "the size of the file minus 8 bytes". More info here: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html

Change-Id: I72948868c4da88556b022ca2c583a351c5019022
