### PR TITLE
tinymix: Add support for passing control name

### DIFF
--- a/tinymix.c
+++ b/tinymix.c
@@ -32,9 +32,9 @@
 #include <ctype.h>
 
 static void tinymix_list_controls(struct mixer *mixer);
-static void tinymix_detail_control(struct mixer *mixer, unsigned int id,
+static void tinymix_detail_control(struct mixer *mixer, const char *control,
                                    int print_all);
-static void tinymix_set_value(struct mixer *mixer, unsigned int id,
+static void tinymix_set_value(struct mixer *mixer, const char *control,
                               char *value);
 static void tinymix_print_enum(struct mixer_ctl *ctl, int print_all);
 
@@ -63,9 +63,9 @@ int main(int argc, char **argv)
     if (argc == 1)
         tinymix_list_controls(mixer);
     else if (argc == 2)
-        tinymix_detail_control(mixer, atoi(argv[1]), 1);
+        tinymix_detail_control(mixer, argv[1], 1);
     else if (argc == 3)
-        tinymix_set_value(mixer, atoi(argv[1]), argv[2]);
+        tinymix_set_value(mixer, argv[1], argv[2]);
     else
         printf("Usage: tinymix [-D card] [control id] [value to set]\n");
 
@@ -93,7 +93,7 @@ static void tinymix_list_controls(struct mixer *mixer)
         type = mixer_ctl_get_type_string(ctl);
         num_values = mixer_ctl_get_num_values(ctl);
         printf("%d\t%s\t%d\t%-40s", i, type, num_values, name);
-        tinymix_detail_control(mixer, i, 0);
+        tinymix_detail_control(mixer, name, 0);
     }
 }
 
@@ -115,7 +115,7 @@ static void tinymix_print_enum(struct mixer_ctl *ctl, int print_all)
     }
 }
 
-static void tinymix_detail_control(struct mixer *mixer, unsigned int id,
+static void tinymix_detail_control(struct mixer *mixer, const char *control,
                                    int print_all)
 {
     struct mixer_ctl *ctl;
@@ -124,12 +124,15 @@ static void tinymix_detail_control(struct mixer *mixer, unsigned int id,
     unsigned int i;
     int min, max;
 
-    if (id >= mixer_get_num_ctls(mixer)) {
+    if (isdigit(control[0]))
+        ctl = mixer_get_ctl(mixer, atoi(control));
+    else
+        ctl = mixer_get_ctl_by_name(mixer, control);
+
+    if (!ctl) {
         fprintf(stderr, "Invalid mixer control\n");
         return;
     }
-
-    ctl = mixer_get_ctl(mixer, id);
 
     type = mixer_ctl_get_type(ctl);
     num_values = mixer_ctl_get_num_values(ctl);
@@ -168,7 +171,7 @@ static void tinymix_detail_control(struct mixer *mixer, unsigned int id,
     printf("\n");
 }
 
-static void tinymix_set_value(struct mixer *mixer, unsigned int id,
+static void tinymix_set_value(struct mixer *mixer, const char *control,
                               char *string)
 {
     struct mixer_ctl *ctl;
@@ -176,7 +179,16 @@ static void tinymix_set_value(struct mixer *mixer, unsigned int id,
     unsigned int num_values;
     unsigned int i;
 
-    ctl = mixer_get_ctl(mixer, id);
+    if (isdigit(control[0]))
+        ctl = mixer_get_ctl(mixer, atoi(control));
+    else
+        ctl = mixer_get_ctl_by_name(mixer, control);
+
+    if (!ctl) {
+        fprintf(stderr, "Invalid mixer control\n");
+        return;
+    }
+
     type = mixer_ctl_get_type(ctl);
     num_values = mixer_ctl_get_num_values(ctl);
 


### PR DESCRIPTION
Allow mixer controls to be accessed through the name, not only by id.

Signed-off-by: Misael Lopez Cruz misael.lopez@ti.com
