### PR TITLE
Mixer.c's int_to_percent return value was 0 or 1

### DIFF
--- a/mixer.c
+++ b/mixer.c
@@ -264,7 +264,7 @@ static int int_to_percent(struct snd_ctl_elem_info *ei, int value)
     if (range == 0)
         return 0;
 
-    return ((value - ei->value.integer.min) / range) * 100;
+    return (int) ((double) ((value - ei->value.integer.min) * 100) / (double) range);
 }
 
 int mixer_ctl_get_percent(struct mixer_ctl *ctl, unsigned int id)


### PR DESCRIPTION
Mixer.c's int_to_percent return value was 0 when value was < range or 1 when value was = range.