### PR TITLE
pcm_get_htimestamp can now use CLOCK_MONOTONIC

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -55,6 +55,7 @@ struct pcm;
                                    * second call to pcm_write will attempt to
                                    * restart the stream.
                                    */
+#define PCM_MONOTONIC  0x00000008 /* see pcm_get_htimestamp */
 
 /* PCM runtime states */
 #define	PCM_STATE_OPEN		0
@@ -166,6 +167,8 @@ unsigned int pcm_bytes_to_frames(struct pcm *pcm, unsigned int bytes);
 unsigned int pcm_get_latency(struct pcm *pcm);
 
 /* Returns available frames in pcm buffer and corresponding time stamp.
+ * The clock is CLOCK_MONOTONIC if flag PCM_MONOTONIC was specified in pcm_open,
+ * otherwise the clock is CLOCK_REALTIME.
  * For an input stream, frames available are frames ready for the
  * application to read.
  * For an output stream, frames available are the number of empty frames available

--- a/pcm.c
+++ b/pcm.c
@@ -719,6 +719,17 @@ struct pcm *pcm_open(unsigned int card, unsigned int device,
         goto fail;
     }
 
+#ifdef SNDRV_PCM_IOCTL_TTSTAMP
+    if (pcm->flags & PCM_MONOTONIC) {
+        int arg = SNDRV_PCM_TSTAMP_TYPE_MONOTONIC;
+        rc = ioctl(pcm->fd, SNDRV_PCM_IOCTL_TTSTAMP, &arg);
+        if (rc < 0) {
+            oops(pcm, rc, "cannot set timestamp type");
+            goto fail;
+        }
+    }
+#endif
+
     pcm->underruns = 0;
     return pcm;
 


### PR DESCRIPTION
Previously the timebase was not documented.  Now a new pcm_open flag
can be used to specify the clock.  If flag PCM_MONOTONIC is specified,
then pcm_open uses SNDRV_PCM_IOCTL_TTSTAMP with parameter
SNDRV_PCM_TSTAMP_TYPE_MONOTONIC to request timestamps in CLOCK_MONOTONIC.

Change-Id: I40ce359cb38d686cbb2521fb0602a8a17ab4f925
