### PR TITLE
tinymix: Improve detect of integer values

### DIFF
--- a/tinymix.c
+++ b/tinymix.c
@@ -31,6 +31,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <limits.h>
+#include <errno.h>
 
 static void tinymix_list_controls(struct mixer *mixer);
 static void tinymix_detail_control(struct mixer *mixer, const char *control,
@@ -175,6 +177,20 @@ static void tinymix_detail_control(struct mixer *mixer, const char *control,
     printf("\n");
 }
 
+static int is_int(char *value)
+{
+    char* end;
+    long int result;
+
+    errno = 0;
+    result = strtol(value, &end, 10);
+
+    if (result == LONG_MIN || result == LONG_MAX)
+        return 0;
+
+    return errno == 0 && *end == '\0';
+}
+
 static void tinymix_set_value(struct mixer *mixer, const char *control,
                               char **values, unsigned int num_values)
 {
@@ -196,7 +212,7 @@ static void tinymix_set_value(struct mixer *mixer, const char *control,
     type = mixer_ctl_get_type(ctl);
     num_ctl_values = mixer_ctl_get_num_values(ctl);
 
-    if (isdigit(values[0][0])) {
+    if (is_int(values[0])) {
         if (num_values == 1) {
             /* Set all values the same */
             int value = atoi(values[0]);


### PR DESCRIPTION
Tinymix detected integer values when setting controls simply by calling
isdigit on the first character of the value being set. This causes
problems with enumerated controls whos values start with digits. This
patch improves this to provide more robust detection of integer values.
