### PR TITLE
Add a function to disambiguate duplicate control names

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -215,6 +215,9 @@ const char *mixer_get_name(struct mixer *mixer);
 unsigned int mixer_get_num_ctls(struct mixer *mixer);
 struct mixer_ctl *mixer_get_ctl(struct mixer *mixer, unsigned int id);
 struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name);
+struct mixer_ctl *mixer_get_ctl_by_name_and_index(struct mixer *mixer,
+                                                  const char *name,
+                                                  unsigned int index);
 
 /* Get info about mixer controls */
 const char *mixer_ctl_get_name(struct mixer_ctl *ctl);

--- a/mixer.c
+++ b/mixer.c
@@ -192,6 +192,13 @@ struct mixer_ctl *mixer_get_ctl(struct mixer *mixer, unsigned int id)
 
 struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name)
 {
+    return mixer_get_ctl_by_name_and_index(mixer, name, 0);
+}
+
+struct mixer_ctl *mixer_get_ctl_by_name_and_index(struct mixer *mixer,
+                                                  const char *name,
+                                                  unsigned int index)
+{
     unsigned int n;
 
     if (!mixer)
@@ -199,7 +206,8 @@ struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name)
 
     for (n = 0; n < mixer->count; n++)
         if (!strcmp(name, (char*) mixer->elem_info[n].id.name))
-            return mixer->ctl + n;
+            if (index-- == 0)
+                return mixer->ctl + n;
 
     return NULL;
 }


### PR DESCRIPTION
Control names are not unique and can be shared by multiple mixers controls.
When this happens, there is no way of accessing the mixer using its control
name, because mixer_get_ctl_by_name() always returns the first match. The only
way of accessing the mixer is through its control number, i.e. using
mixer_get_ctl().

This patch adds the function mixer_get_ctl_by_name_and_index() to offer the
possibility to retrieve a control through its name and index.  This index
corresponds to the nth occurence of the control name in the global supported
controls names list.

Change-Id: Ie29bf2a949ecf69f106bbe359155cdbfbe98928c
Signed-off-by: Frédéric Boisnard <fredericx.boisnard@intel.com>
Signed-off-by: David Wagner <david.wagner@intel.com>
Signed-off-by: Bruce Beare <bruce.j.beare@intel.com>
Signed-off-by: Jack Ren <jack.ren@intel.com>
Author-Tracking-BZ: 139255