### PR TITLE
Add separate call for pcm prepare

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -189,6 +189,8 @@ int pcm_mmap_begin(struct pcm *pcm, void **areas, unsigned int *offset,
                    unsigned int *frames);
 int pcm_mmap_commit(struct pcm *pcm, unsigned int offset, unsigned int frames);
 
+/* Prepare the PCM substream to be triggerable */
+int pcm_prepare(struct pcm *pcm);
 /* Start and stop a PCM channel that doesn't transfer data */
 int pcm_start(struct pcm *pcm);
 int pcm_stop(struct pcm *pcm);


### PR DESCRIPTION
Tinyalsa combines PREPARE and START calls to the driver in the pcm_start()
function.  Typically, this is needed for making a driver allocating hardware
resources that are not related to a PCM stream.

Change-Id: Ic83fad784936bbebab28e8e425debd449182db88
Signed-off-by: Omair Mohammed Abdullah omair.m.abdullah@linux.intel.com
Signed-off-by: David Wagner david.wagner@intel.com
Signed-off-by: Bruce Beare bruce.j.beare@intel.com
Signed-off-by: Jack Ren jack.ren@intel.com
Author-Tracking-BZ: 73509
