### PR TITLE
Mixer: Check validity of input value

### DIFF
--- a/mixer.c
+++ b/mixer.c
@@ -392,6 +392,11 @@ int mixer_ctl_set_value(struct mixer_ctl *ctl, unsigned int id, int value)
         break;
 
     case SNDRV_CTL_ELEM_TYPE_INTEGER:
+        if ((value < mixer_ctl_get_range_min(ctl)) ||
+            (value > mixer_ctl_get_range_max(ctl))) {
+            return -EINVAL;
+        }
+
         ev.value.integer.value[id] = value;
         break;
 


### PR DESCRIPTION
When the user wants to set a mixer with a value greater
than the maximum or smaller than the minimum, the mixer
is set at an undefined value.

This patch set purpose is to return a error if the input
value is out of range.

Signed-off-by: Baptiste Robert baptistex.robert@intel.com
Signed-off-by: David Wagner david.wagner@intel.com
Author-Tracking-BZ: 129089
