### PR TITLE
Revert "mixer: Control input value in mixer_ctl_set_value"

### DIFF
--- a/mixer.c
+++ b/mixer.c
@@ -383,9 +383,6 @@ int mixer_ctl_set_value(struct mixer_ctl *ctl, unsigned int id, int value)
     if (ret < 0)
         return ret;
 
-    if (value > mixer_ctl_get_range_max(ctl))
-        value = mixer_ctl_get_range_max(ctl);
-
     switch (ctl->info->type) {
     case SNDRV_CTL_ELEM_TYPE_BOOLEAN:
         ev.value.integer.value[id] = !!value;


### PR DESCRIPTION
This reverts commit 0e07647e4b9c52bb5f3766f9564ed38b6030e556.

This commit disables reporting of an error when somebody requests an out
of range value from a control which seems like a bad goal to start with,
if something invalid is requested we should return an error not set
things to the nearest valid state.

Secondly since mixer_ctl_get_range_max returns an error for all control
types except TYPE_INTEGER, all controls that are not integers will be
set to -EINVAL with this patch included.

Signed-off-by: Charles Keepax ckeepax@opensource.wolfsonmicro.com
