### PR TITLE
Add capability to set one value of a byte mixer

### DIFF
--- a/mixer.c
+++ b/mixer.c
@@ -404,6 +404,10 @@ int mixer_ctl_set_value(struct mixer_ctl *ctl, unsigned int id, int value)
         ev.value.enumerated.item[id] = value;
         break;
 
+    case SNDRV_CTL_ELEM_TYPE_BYTES:
+        ev.value.bytes.data[id] = value;
+        break;
+
     default:
         return -EINVAL;
     }


### PR DESCRIPTION
The mixer_ctl_set_value function doesn't support setting byte controls.

This is necessary for 1-byte-long byte controls
