### PR TITLE
mixer: Add mixer_ctl_get_id

### DIFF
--- a/include/tinyalsa/asoundlib.h
+++ b/include/tinyalsa/asoundlib.h
@@ -225,6 +225,7 @@ struct mixer_ctl *mixer_get_ctl(struct mixer *mixer, unsigned int id);
 struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name);
 
 /* Get info about mixer controls */
+unsigned int mixer_ctl_get_id(struct mixer_ctl *ctl);
 const char *mixer_ctl_get_name(struct mixer_ctl *ctl);
 enum mixer_ctl_type mixer_ctl_get_type(struct mixer_ctl *ctl);
 const char *mixer_ctl_get_type_string(struct mixer_ctl *ctl);

--- a/mixer.c
+++ b/mixer.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <ctype.h>
+#include <limits.h>
 
 #include <sys/ioctl.h>
 
@@ -207,6 +208,17 @@ struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name)
 void mixer_ctl_update(struct mixer_ctl *ctl)
 {
     ioctl(ctl->mixer->fd, SNDRV_CTL_IOCTL_ELEM_INFO, ctl->info);
+}
+
+unsigned int mixer_ctl_get_id(struct mixer_ctl *ctl)
+{
+    if (!ctl)
+        return UINT_MAX;
+
+    /* numid values start at 1, return a 0-base value that
+     * can be passed to mixer_get_ctl()
+     */
+    return ctl->info->id.numid - 1;
 }
 
 const char *mixer_ctl_get_name(struct mixer_ctl *ctl)


### PR DESCRIPTION
Add a function to get an id of a control that can be
passed to mixer_get_ctl(). This can be used to lookup
a control by name and store its id for later use rather
than have the overhead of name lookup each time it is
used. Lookup by id is quick and avoids the disadvantage
that storing a pointer to the mixer_ctl object creates
a client with a dependency on the address of the internal
control array.

Signed-off-by: Richard Fitzgerald <rf@opensource.wolfsonmicro.com>