### PR TITLE
pcm: fix the boundary issue on pcm_mmap_playback_avail()

### DIFF
--- a/pcm.c
+++ b/pcm.c
@@ -827,7 +827,7 @@ static inline int pcm_mmap_playback_avail(struct pcm *pcm)
 
     if (avail < 0)
         avail += pcm->boundary;
-    else if (avail > (int)pcm->boundary)
+    else if (avail >= (int)pcm->boundary)
         avail -= pcm->boundary;
 
     return avail;


### PR DESCRIPTION
avail should be zero when (hw_ptr + buffer_size - appl_ptr)
reaches to pcm->boundary on pcm_mmap_playback_avail().