### PR TITLE
tinypcminfo: make function pcm_get_format_name() static

### DIFF
--- a/tinypcminfo.c
+++ b/tinypcminfo.c
@@ -92,7 +92,7 @@ static const char *format_lookup[] = {
 /* Returns a human readable name for the format associated with bit_index,
  * NULL if bit_index is not known.
  */
-inline const char *pcm_get_format_name(unsigned bit_index)
+static inline const char *pcm_get_format_name(unsigned bit_index)
 {
     return bit_index < ARRAY_SIZE(format_lookup) ? format_lookup[bit_index] : NULL;
 }


### PR DESCRIPTION
When building tinyalsa with gcc 5.x, the following warnings appear:

tinypcminfo.c:97:52: warning: 'format_lookup' is static but used in inline function 'pcm_get_format_name' which is not static
     return bit_index < ARRAY_SIZE(format_lookup) ? format_lookup[bit_index] : NULL;
                                                    ^
tinypcminfo.c:97:35: warning: 'format_lookup' is static but used in inline function 'pcm_get_format_name' which is not static
     return bit_index < ARRAY_SIZE(format_lookup) ? format_lookup[bit_index] : NULL;

And the build fails with:

tinypcminfo.o: In function `main':
tinypcminfo.c:(.text+0x2f0): undefined reference to `pcm_get_format_name'
collect2: error: ld returned 1 exit status

To fix this, this patch marks the pcm_get_format_name() as static,
since it's anyway only used in tinypcminfo.c.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>