### PR TITLE
initialize pcm_config to zero

### DIFF
--- a/tinycap.c
+++ b/tinycap.c
@@ -174,6 +174,7 @@ unsigned int capture_sample(FILE *file, unsigned int card, unsigned int device,
     unsigned int size;
     unsigned int bytes_read = 0;
 
+    memset(&config, 0, sizeof(config));
     config.channels = channels;
     config.rate = rate;
     config.period_size = period_size;

--- a/tinyplay.c
+++ b/tinyplay.c
@@ -218,6 +218,7 @@ void play_sample(FILE *file, unsigned int card, unsigned int device, unsigned in
     int size;
     int num_read;
 
+    memset(&config, 0, sizeof(config));
     config.channels = channels;
     config.rate = rate;
     config.period_size = period_size;


### PR DESCRIPTION
sw_params ioctl() is failing with 'invalid parameter' error
since pointer to pcm_config passed from tinyplay is not zero
initialized, hence invalid values are passed for some
parameters.

authored-by: Shiv Maliyappanahalli <smaliyap@codeaurora.org>

Bug: 23525433
Change-Id: I841f29c82ec3fb7646ad8c47fca25963b5f77945