### PR TITLE
asound.h: include <time.h> to get struct timespec prototype

### DIFF
--- a/include/sound/asound.h
+++ b/include/sound/asound.h
@@ -12,6 +12,7 @@
 #ifndef __SOUND_ASOUND_H
 #define __SOUND_ASOUND_H
 
+#include <time.h>
 #include <linux/types.h>
 
 #define SNDRV_PROTOCOL_VERSION(major, minor, subminor) (((major)<<16)|((minor)<<8)|(subminor))


### PR DESCRIPTION
without including it, we get
In file included from mixer.c:44:0:
include/sound/asound.h:337:18: error: field 'trigger_tstamp' has incomplete type
include/sound/asound.h:338:18: error: field 'tstamp' has incomplete type
etc.

note that time.h is included first so linux' libc-compat.h can kick in and prevent userspace/kernel header collisions.
using ```<linux/time.h>``` instead of ```<time.h>``` leads to said problems:
```
gcc -c -fPIC -Wall mixer.c -Iinclude
In file included from /usr/include/sys/select.h:16:0,
                 from /usr/include/sys/time.h:9,
                 from include/tinyalsa/asoundlib.h:32,
                 from mixer.c:46:
/usr/include/bits/alltypes.h:265:8: error: redefinition of 'struct timeval'
```