### PR TITLE
include time.h, to prevent use of struct timespec before definition

### DIFF
--- a/mixer.c
+++ b/mixer.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <limits.h>
+#include <time.h>
 
 #include <sys/ioctl.h>
 

--- a/pcm.c
+++ b/pcm.c
@@ -38,6 +38,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/time.h>
+#include <time.h>
 #include <limits.h>
 
 #include <linux/ioctl.h>


### PR DESCRIPTION
In some old (2.6.32.x) kernel headers, asound.h does not include linux time.h
when __KERNEL__ is undefined, which may break userspace.

The build failures caused by this are similar to those fixed by c8333f8c.

Signed-off-by: Dima Krasner <dima@dimakrasner.com>