### PR TITLE
EOF tested on riff/wav audio file as corrupted streams loop infinitely

### DIFF
--- a/tinyplay.c
+++ b/tinyplay.c
@@ -163,6 +163,12 @@ int main(int argc, char **argv)
         }
         do {
             fread(&chunk_header, sizeof(chunk_header), 1, file);
+	    if(!feof(file))
+	    {
+		fprintf(stderr, "Error: End of file, suspected %s ,corrupted riff/wav file\n",filename);
+		fclose(file);
+		return 1;
+            }
             switch (chunk_header.id) {
             case ID_FMT:
                 fread(&chunk_fmt, sizeof(chunk_fmt), 1, file);


### PR DESCRIPTION


    Hi,
    I noticed one issue with tinyplay .
    with corrupted wav stream , tinyplay command loops for ever at start of tinyplay.c till
    chunk_header.id equals ID_DATA .
    When playing corrupted wav streams sometimes this condition is not met and loops forever on command line.
    tinyplay test.wav -D 0 -d 0 -p 2048 -n 4 -c 1
    where test.wav is corrupted stream
    patch takes care of EOF
    patch info 
    
 tinyplay.c |    6 ++++++
 1 file changed, 6 insertions(+)

diff --git a/tinyplay.c b/tinyplay.c
index 920b0e8..0b80376 100644
--- a/tinyplay.c
+++ b/tinyplay.c
@@ -163,6 +163,12 @@ int main(int argc, char **argv)
         }
         do {
             fread(&chunk_header, sizeof(chunk_header), 1, file);
+	    if(!feof(file))
+	    {
+		fprintf(stderr, "Error: End of file, suspected %s ,corrupted riff/wav file\n",filename);
+		fclose(file);
+		return 1;
+            }
             switch (chunk_header.id) {
             case ID_FMT:
                 fread(&chunk_fmt, sizeof(chunk_fmt), 1, file);
-- 
 Best Regards,
vivek

