### PR TITLE
We can include only necessary headers!?

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -45,7 +45,7 @@
 #define __user
 #include <sound/asound.h>
 
-#include <tinyalsa/asoundlib.h>
+#include <tinyalsa/mixer.h>
 
 /** A mixer control.
  * @ingroup tinyalsa-mixer

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -47,7 +47,7 @@
 #define __user
 #include <sound/asound.h>
 
-#include <tinyalsa/asoundlib.h>
+#include <tinyalsa/pcm.h>
 
 #define PARAM_MAX SNDRV_PCM_HW_PARAM_LAST_INTERVAL
 #define SNDRV_PCM_HW_PARAMS_NO_PERIOD_WAKEUP (1<<2)


### PR DESCRIPTION
If users want to use only **pcm.c** or **mixer.c** they can, right?
Is it necessary to include _tinyalsa/asoundlib.h_ given that **mixer.c** doesn't use **pcm.h** and **pcm.c** doesn't use **mixer.h**.