### PR TITLE
Add a Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+os: linux
+sudo: false
+language: c
+compiler: gcc
+
+addons:
+    apt:
+        packages:
+            - doxygen
+            - graphviz
+
+script:
+    - make


### PR DESCRIPTION
Travis CI is a CI service, free to use for open-source projects. It can automatically build any incoming Pull Request and catch build errors provided that the project's administrator activates Travis CI on the repository.

See https://travis-ci.org https://docs.travis-ci.com