### PR TITLE
pcm.h -- (over/under)run definition

### DIFF
--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -94,8 +94,8 @@ extern "C" {
  */
 #define	PCM_STATE_RUNNING	0x03
 
-/** For inputs, this means an underrun occured.
- * For outputs, this means an overrun occured.
+/** For inputs, this means an overrun occured.
+ * For outputs, this means an underrun occured.
  */
 #define	PCM_STATE_XRUN 0x04
 


### PR DESCRIPTION
As we may see in <http://www.alsa-project.org/alsa-doc/alsa-lib/pcm.html>, the **XRUN** state
takes place when _"The PCM device reached **overrun (capture)** or **underrun (playback)**."_