### PR TITLE
Tvl fix

### DIFF
--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -107,6 +107,8 @@ const char *mixer_ctl_get_enum_string(struct mixer_ctl *ctl, unsigned int enum_i
  */
 void mixer_ctl_update(struct mixer_ctl *ctl);
 
+int mixer_ctl_is_access_tlv_rw(const struct mixer_ctl *ctl);
+
 /* Set and get mixer controls */
 int mixer_ctl_get_percent(const struct mixer_ctl *ctl, unsigned int id);
 

--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -41,6 +41,9 @@
 extern "C" {
 #endif
 
+/* TLV header size*/
+#define TLV_HEADER_SIZE (2 * sizeof(unsigned int))
+
 struct mixer;
 
 struct mixer_ctl;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -590,8 +590,20 @@ int mixer_ctl_get_array(const struct mixer_ctl *ctl, void *array, size_t count)
     int ret = 0;
     size_t size;
     void *source;
+    size_t total_count;
 
-    if (!ctl || (count > ctl->info.count) || !count || !array)
+    if ((!ctl) || !count || !array)
+        return -EINVAL;
+
+    total_count = ctl->info.count;
+
+    if ((ctl->info.type == SNDRV_CTL_ELEM_TYPE_BYTES) &&
+        (mixer_ctl_is_access_tlv_rw(ctl))) {
+            /* Additional two words is for the TLV header */
+            total_count += TLV_HEADER_SIZE;
+    }
+
+    if (count > total_count)
         return -EINVAL;
 
     memset(&ev, 0, sizeof(ev));
@@ -714,8 +726,20 @@ int mixer_ctl_set_array(struct mixer_ctl *ctl, const void *array, size_t count)
     struct snd_ctl_elem_value ev;
     size_t size;
     void *dest;
+    size_t total_count;
 
-    if (!ctl || (count > ctl->info.count) || !count || !array)
+    if ((!ctl) || !count || !array)
+        return -EINVAL;
+
+    total_count = ctl->info.count;
+
+    if ((ctl->info.type == SNDRV_CTL_ELEM_TYPE_BYTES) &&
+        (mixer_ctl_is_access_tlv_rw(ctl))) {
+            /* Additional TLV header */
+            total_count += TLV_HEADER_SIZE;
+    }
+
+    if (count > total_count)
         return -EINVAL;
 
     memset(&ev, 0, sizeof(ev));

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -381,6 +381,17 @@ void mixer_ctl_update(struct mixer_ctl *ctl)
     ioctl(ctl->mixer->fd, SNDRV_CTL_IOCTL_ELEM_INFO, ctl->info);
 }
 
+/** Checks the control for TLV Read/Write access.
+ * @param ctl An initialized control handle.
+ * @returns On success, non-zero.
+ *  On failure, zero.
+ * @ingroup libtinyalsa-mixer
+ */
+int mixer_ctl_is_access_tlv_rw(const struct mixer_ctl *ctl)
+{
+    return (ctl->info.access & SNDRV_CTL_ELEM_ACCESS_TLV_READWRITE);
+}
+
 /** Gets the control's ID.
  * @param ctl An initialized control handle.
  * @returns On success, the control's ID is returned.
@@ -598,7 +609,7 @@ int mixer_ctl_get_array(const struct mixer_ctl *ctl, void *array, size_t count)
 
     case SNDRV_CTL_ELEM_TYPE_BYTES:
         /* check if this is new bytes TLV */
-        if (ctl->info.access & SNDRV_CTL_ELEM_ACCESS_TLV_READWRITE) {
+        if (mixer_ctl_is_access_tlv_rw(ctl)) {
             struct snd_ctl_tlv *tlv;
             int ret;
 
@@ -719,7 +730,7 @@ int mixer_ctl_set_array(struct mixer_ctl *ctl, const void *array, size_t count)
 
     case SNDRV_CTL_ELEM_TYPE_BYTES:
         /* check if this is new bytes TLV */
-        if (ctl->info.access & SNDRV_CTL_ELEM_ACCESS_TLV_READWRITE) {
+        if (mixer_ctl_is_access_tlv_rw(ctl)) {
             struct snd_ctl_tlv *tlv;
             int ret = 0;
             if (count > SIZE_MAX - sizeof(*tlv))


### PR DESCRIPTION
tinymix get method reads incorrect values and crashes while reading TLV byte related controls.
The TLV byte controls expect a TLV header as well, so add that before invoking mixer API to fix the issue.
