### PR TITLE
Fix mixer_wait_event function comments

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -321,8 +321,9 @@ int mixer_subscribe_events(struct mixer *mixer, int subscribe)
 /** Wait for mixer events.
  * @param mixer A mixer handle.
  * @param timeout timout value
- * @returns On success, zero.
- *  On failure, non-zero.
+ * @returns On success, 1.
+ *  On failure, -errno.
+ *  On timeout, 0
  * @ingroup libtinyalsa-mixer
  */
 int mixer_wait_event(struct mixer *mixer, int timeout)


### PR DESCRIPTION
The @return comment description incorrect.
Fix it.

Change-Id: I148a5ebf3e05eb4824beb4c8fa1032a38272d86d
Signed-off-by: Pankaj Bharadiya <pankaj.laxminarayan.bharadiya@intel.com>