### PR TITLE
tinymix: fix segfaults with set command

### DIFF
--- a/utils/tinymix.c
+++ b/utils/tinymix.c
@@ -124,7 +124,12 @@ int main(int argc, char **argv)
             mixer_close(mixer);
             return EXIT_FAILURE;
         }
-        tinymix_set_value(mixer, argv[optind + 1], &argv[optind + 2], argc - 2);
+	if ((optind + 2) >= argc) {
+            fprintf(stderr, "no value(s) specified\n");
+            mixer_close(mixer);
+            return EXIT_FAILURE;
+        }
+        tinymix_set_value(mixer, argv[optind + 1], &argv[optind + 2], argc - 3);
     } else if (strcmp(cmd, "controls") == 0) {
         tinymix_list_controls(mixer, 0);
     } else if (strcmp(cmd, "contents") == 0) {


### PR DESCRIPTION
The arguments passed after the set command are not handled properly,
leading to segfaults or inability to set controls

Example with control 0 which is Headset Volume on my NUC:

before fix
$ ./tinymix set 0
Segmentation fault
$ ./tinymix set 0 10
Segmentation fault
$ ./tinymix set 0 10 20
Error: 3 values given, but control only takes 2

After correction
$ ./tinymix set 0
no value(s) specified
$ ./tinymix set 0 10
$ ./tinymix set 0 10 10
$ ./tinymix set 0 10 10 10
Error: 3 values given, but control only takes 2

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>