### PR TITLE
Fix to pass num_frames to pcm_writei

### DIFF
--- a/utils/tinyplay.c
+++ b/utils/tinyplay.c
@@ -409,7 +409,8 @@ int play_sample(struct ctx *ctx)
     do {
         num_read = fread(buffer, 1, size, ctx->file);
         if (num_read > 0) {
-            if (pcm_writei(ctx->pcm, buffer, num_read) < 0) {
+		if (pcm_writei(ctx->pcm, buffer,
+			pcm_bytes_to_frames(ctx->pcm, num_read)) < 0) {
                 fprintf(stderr, "error playing sample\n");
                 break;
             }


### PR DESCRIPTION
pcm_writei expects size of data in frames, whereas currently size
is passed as number of bytes. So convert number of bytes to frames
for argument to pcm_writei.

Signed-off-by: Jaikrishna Nemallapudi <jaikrishnax.nemallapudi@intel.com>
Signed-off-by: Subhransu S. Prusty <subhransu.s.prusty@intel.com>