### PR TITLE
interval.h: add missing header

### DIFF
--- a/include/tinyalsa/interval.h
+++ b/include/tinyalsa/interval.h
@@ -30,6 +30,7 @@
 #define TINYALSA_INTERVAL_H
 
 #include <stdlib.h>
+#include <unistd.h>
 
 /** A closed range signed interval. */
 


### PR DESCRIPTION
The ssize_t type requires the unistd.h header. This fixes build with musl
libc:

In file included from ../include/tinyalsa/limits.h:32:0,
                 from limits.c:1:
../include/tinyalsa/interval.h:38:2: error: unknown type name 'ssize_t'
  ssize_t max;
  ^

Signed-off-by: Baruch Siach <baruch@tkos.co.il>