### PR TITLE
Fix pcm_writei return value if pcm is in not running state.

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -695,7 +695,7 @@ int pcm_writei(struct pcm *pcm, const void *data, unsigned int frame_count)
             if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_WRITEI_FRAMES, &x))
                 return oops(pcm, errno, "cannot write initial data");
             pcm->running = 1;
-            return 0;
+            return x.result;
         }
         if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_WRITEI_FRAMES, &x)) {
             pcm->prepared = 0;


### PR DESCRIPTION
As per comment, on success, pcm_writei returns the number of frames written.
Fix the case of pcm not running.

Signed-off-by: Miguel GAIO <mgaio35@gmail.com>