### PR TITLE
Add support for Meson as build system

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,8 @@
+examples = ['pcm-readi', 'pcm-writei']
+
+foreach e : examples
+  executable(e, '@0@.c'.format(e),
+    include_directories: tinyalsa_includes,
+    link_with: tinyalsa,
+    install: false)
+endforeach

--- a/include/tinyalsa/meson.build
+++ b/include/tinyalsa/meson.build
@@ -1,0 +1,10 @@
+tinyalsa_headers = [
+  'asoundlib.h',
+  'interval.h',
+  'limits.h',
+  'mixer.h',
+  'pcm.h',
+  'version.h'
+]
+
+install_headers(tinyalsa_headers, subdir: 'tinyalsa')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,29 @@
+project ('tinyalsa', 'c', version : '1.1.1', meson_version : '>= 0.48.0')
+
+tinyalsa_includes = include_directories('.', 'include')
+
+tinyalsa = library('tinyalsa',
+  'src/mixer.c', 'src/pcm.c',
+  include_directories: tinyalsa_includes,
+  install: true)
+
+# For use as a Meson subproject
+tinyalsa_dep = declare_dependency(link_with: tinyalsa,
+  include_directories: include_directories('include'))
+
+if not get_option('docs').disabled()
+  # subdir('docs') # FIXME
+endif
+
+if not get_option('examples').disabled()
+  subdir('examples')
+endif
+
+subdir('include/tinyalsa')
+
+if not get_option('utils').disabled()
+  subdir('utils')
+endif
+
+pkg = import('pkgconfig')
+pkg.generate(tinyalsa, description: 'TinyALSA Library')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option('docs', type: 'feature', value: 'auto', yield: true,
+  description : 'Generate documentation with Doxygen')
+option('examples', type: 'feature', value: 'auto', yield: true,
+  description : 'Build examples')
+option('utils', type: 'feature', value: 'auto', yield: true,
+  description : 'Build utility tools')

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -1,0 +1,9 @@
+utils = ['tinyplay', 'tinycap', 'tinymix', 'tinypcminfo']
+
+foreach util : utils
+  executable(util, '@0@.c'.format(util),
+    include_directories: tinyalsa_includes,
+    link_with: tinyalsa,
+    install: true)
+  install_man('@0@.1'.format(util))
+endforeach


### PR DESCRIPTION
Hi,

Please find attached a patch that adds support for building TinyALSA with the Meson build system.

I understand that from a maintainer's point of view these kind of unsolicited "add support for a different build system" patches are not always welcome, not least because they might add additional maintenance burden, so apologies in advance for that. I would be happy to help maintain them going forward, along with other GStreamer maintainers.

The Meson build system is being adopted by projects such as GNOME, PulseAudio, GStreamer, VLC, systemd, Mesa, Wayland, X.org, and many others.

Having a meson build upstream in tinyalsa would allow for easy use of TinyALSA as a Meson subproject in other projects.

Cross-compilation is of course also supported, but I have not tested that yet.

To try the meson build:

    $ meson --prefix=/tmp/prefix builddir
    $ ninja -C builddir
    $ ninja -C builddir install

You can install a recent Meson version with pip3 if your system does not have a recent one on your system. You can also run Meson straight from a git checkout, since it's just python code.

Thanks for your consideration. Any questions, just let me know!

CC @ford-prefect @nirbheek