### PR TITLE
meson: extract project version from header file and version .so

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,13 @@
-project ('tinyalsa', 'c', version : '1.1.1', meson_version : '>= 0.48.0')
+project ('tinyalsa', 'c',
+  version : run_command(find_program('version.py')).stdout().strip(),
+  meson_version : '>= 0.48.0')
 
 tinyalsa_includes = include_directories('.', 'include')
 
 tinyalsa = library('tinyalsa',
   'src/mixer.c', 'src/pcm.c',
   include_directories: tinyalsa_includes,
+  version: meson.project_version(),
   install: true)
 
 # For use as a Meson subproject

--- a/version.py
+++ b/version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# tinyalsa version.py: Extracts versions from TINYALSA_VERSION_STRING in
+# include/tinyalsa/version.h header file for Meson build.
+import os
+import sys
+
+if __name__ == '__main__':
+    try:
+        srcroot = os.environ['MESON_SOURCE_ROOT']
+    except:
+        srcroot = os.getcwd()
+        print('Warning: MESON_SOURCE_ROOT env var not set, assuming source code is in', srcroot, file=sys.stderr)
+
+    # API version
+    api_version = None
+    f = open(os.path.join(srcroot, 'include', 'tinyalsa', 'version.h'), 'r')
+    for line in f:
+        if line.startswith('#define TINYALSA_VERSION_STRING '):
+            api_version = line[32:].strip().replace('"', '')
+            print(api_version)
+            sys.exit(0)
+
+    print('Warning: Could not extract API version from TINYALSA_VERSION_STRING in include/tinyalsa/version.h in', srcroot, file=sys.stderr)
+    sys.exit(-1)


### PR DESCRIPTION
- Extract project version from `tinyalsa/version.h` for easier maintainability

- Version shared lib: tinyalsa.so -> tinyalsa.so.1.1.1