### PR TITLE
Fix behaviors, remove 'prepared' and 'running' variables

### DIFF
--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -97,6 +97,11 @@ extern "C" {
  * */
 #define PCM_NONBLOCK 0x00000010
 
+/** Means a PCM is prepared
+ * @ingroup libtinyalsa-pcm
+ */
+#define PCM_STATE_PREPARED 0x02
+
 /** For inputs, this means the PCM is recording audio samples.
  * For outputs, this means the PCM is playing audio samples.
  * @ingroup libtinyalsa-pcm

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1325,7 +1325,7 @@ int pcm_mmap_commit(struct pcm *pcm, unsigned int offset, unsigned int frames)
 
 int pcm_avail_update(struct pcm *pcm)
 {
-    pcm_sync_ptr(pcm, 0);
+    pcm_sync_ptr(pcm, SNDRV_PCM_SYNC_PTR_APPL|SNDRV_PCM_SYNC_PTR_AVAIL_MIN);
     return pcm_mmap_avail(pcm);
 }
 

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1259,7 +1259,7 @@ static int pcm_mmap_transfer_areas(struct pcm *pcm, char *buf,
     int commit;
     unsigned int pcm_offset, frames, count = 0;
 
-    while (size > 0) {
+    while (pcm_mmap_avail(pcm) && size) {
         frames = size;
         pcm_mmap_begin(pcm, &pcm_areas, &pcm_offset, &frames);
         pcm_areas_copy(pcm, pcm_offset, buf, offset, frames);

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -703,12 +703,6 @@ int pcm_writei(struct pcm *pcm, const void *data, unsigned int frame_count)
     x.frames = frame_count;
     x.result = 0;
     for (;;) {
-        if (!pcm->running) {
-            if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_WRITEI_FRAMES, &x))
-                return oops(pcm, errno, "cannot write initial data");
-            pcm->running = 1;
-            return x.result;
-        }
         if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_WRITEI_FRAMES, &x)) {
             pcm->prepared = 0;
             pcm->running = 0;

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -549,7 +549,6 @@ static int pcm_hw_mmap_status(struct pcm *pcm)
         pcm->mmap_status = NULL;
         goto mmap_error;
     }
-    pcm->mmap_control->avail_min = 1;
 
     return 0;
 
@@ -560,8 +559,6 @@ mmap_error:
         return -ENOMEM;
     pcm->mmap_status = &pcm->sync_ptr->s.status;
     pcm->mmap_control = &pcm->sync_ptr->c.control;
-    pcm->mmap_control->avail_min = 1;
-    pcm_sync_ptr(pcm, 0);
 
     return 0;
 }

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1192,6 +1192,9 @@ int pcm_prepare(struct pcm *pcm)
     if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_PREPARE) < 0)
         return oops(pcm, errno, "cannot prepare channel");
 
+    /* get appl_ptr and avail_min from kernel */
+    pcm_sync_ptr(pcm, SNDRV_PCM_SYNC_PTR_APPL|SNDRV_PCM_SYNC_PTR_AVAIL_MIN);
+
     return 0;
 }
 

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -913,6 +913,7 @@ struct pcm *pcm_open(unsigned int card, unsigned int device,
     return pcm;
 
 fail:
+    pcm_hw_munmap_status(pcm);
     if (flags & PCM_MMAP)
         munmap(pcm->mmap_buffer, pcm_frames_to_bytes(pcm, pcm->buffer_size));
 fail_close:

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1129,6 +1129,10 @@ struct pcm *pcm_open(unsigned int card, unsigned int device,
     }
 #endif
 
+    /* prepare here so the user does not need to do this later */
+    if (pcm_prepare(pcm))
+        goto fail;
+
     pcm->underruns = 0;
     return pcm;
 

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -760,6 +760,10 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
             if (errno == EPIPE) {
                     /* we failed to make our window -- try to restart */
                 pcm->underruns++;
+                if (pcm->flags & PCM_NORESTART)
+                    return -EPIPE;
+                if (pcm_prepare(pcm))
+                    return -EPIPE;
                 continue;
             }
             return oops(pcm, errno, "cannot read stream data");

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -993,7 +993,8 @@ int pcm_prepare(struct pcm *pcm)
 int pcm_start(struct pcm *pcm)
 {
     /* set appl_ptr and avail_min in kernel */
-    pcm_sync_ptr(pcm, 0);
+    if (pcm_sync_ptr(pcm, 0) < 0)
+        return -1;
 
     if (pcm->mmap_status->state != PCM_STATE_RUNNING) {
         if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_START) < 0)

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -752,9 +752,7 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
     x.frames = frame_count;
     x.result = 0;
     for (;;) {
-        if ((!pcm->running) && (pcm_start(pcm) < 0))
-            return -errno;
-        else if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_READI_FRAMES, &x)) {
+        if (ioctl(pcm->fd, SNDRV_PCM_IOCTL_READI_FRAMES, &x)) {
             pcm->prepared = 0;
             pcm->running = 0;
             if (errno == EPIPE) {

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1205,20 +1205,13 @@ int pcm_prepare(struct pcm *pcm)
 }
 
 /** Starts a PCM.
- * If the PCM has not been prepared,
- * it is prepared in this function.
  * @param pcm A PCM handle.
  * @return On success, zero; on failure, a negative number.
  * @ingroup libtinyalsa-pcm
  */
 int pcm_start(struct pcm *pcm)
 {
-    int prepare_error = pcm_prepare(pcm);
-    if (prepare_error)
-        return prepare_error;
-
-    /* if pcm is linked, it may be already started by other pcm */
-    /* check pcm state is not in running state */
+    /* set appl_ptr and avail_min in kernel */
     pcm_sync_ptr(pcm, 0);
 
     if (pcm->mmap_status->state != PCM_STATE_RUNNING) {

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -215,8 +215,8 @@ struct pcm {
     int fd;
     /** Flags that were passed to @ref pcm_open */
     unsigned int flags;
-    /** The number of underruns that have occured */
-    int underruns;
+    /** The number of (under/over)runs that have occured */
+    int xruns;
     /** Size of the buffer */
     unsigned int buffer_size;
     /** The boundary for ring buffer pointers */
@@ -909,7 +909,7 @@ struct pcm *pcm_open(unsigned int card, unsigned int device,
     if (pcm_prepare(pcm))
         goto fail;
 
-    pcm->underruns = 0;
+    pcm->xruns = 0;
     return pcm;
 
 fail:
@@ -1399,7 +1399,7 @@ again:
     if (res < 0) {
         switch (errno) {
         case EPIPE:
-            pcm->underruns++;
+            pcm->xruns++;
             /* fallthrough */
         case ESTRPIPE:
             /*

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1252,7 +1252,6 @@ static inline int pcm_mmap_capture_avail(struct pcm *pcm)
 
 static inline int pcm_mmap_avail(struct pcm *pcm)
 {
-    pcm_sync_ptr(pcm, SNDRV_PCM_SYNC_PTR_HWSYNC);
     if (pcm->flags & PCM_IN)
         return pcm_mmap_capture_avail(pcm);
     else


### PR DESCRIPTION
Please review this in my fork. In pull requests GitHub reorder commits based on author date.