### PR TITLE
Support Audio dmabuf

### DIFF
--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -316,6 +316,22 @@ int pcm_wait(struct pcm *pcm, int timeout);
 
 long pcm_get_delay(struct pcm *pcm);
 
+int pcm_dmabuf_export(struct pcm *pcm);
+
+int pcm_dmabuf_attach(struct pcm *pcm);
+
+int pcm_dmabuf_detach(struct pcm *pcm);
+
+int pcm_dmabuf_mmap(struct pcm *pcm);
+
+void pcm_dmabuf_munmap(struct pcm *pcm);
+
+int pcm_dmabuf_begin_access(struct pcm *pcm, int direction);
+
+int pcm_dmabuf_end_access(struct pcm *pcm, int direction);
+
+int pcm_dmabuf_fd(struct pcm *pcm);
+
 #if defined(__cplusplus)
 }  /* extern "C" */
 #endif

--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -95,6 +95,12 @@
  * */
 #define PCM_NONBLOCK 0x00000010
 
+/** Specifies that the PCM will use dmabuf methods.
+ * Used in @ref pcm_open.
+ * @ingroup libtinyalsa-pcm
+ */
+#define PCM_DMABUF 0x00000020
+
 /** Means a PCM is prepared
  * @ingroup libtinyalsa-pcm
  */

--- a/utils/tinyplay.c
+++ b/utils/tinyplay.c
@@ -72,6 +72,11 @@ int cmd_parse_arg(struct cmd *cmd, int argc, const char **argv)
         return 1;
     }
 
+    if ((strcmp(argv[0], "-B") == 0) || (strcmp(argv[0], "--dmabuf") == 0)) {
+        cmd->flags |= PCM_DMABUF;
+        return 1;
+    }
+
     if (argv[0][0] != '-' || (strcmp(argv[0],"-") == 0)) {
         cmd->filename = argv[0];
         return 1;
@@ -413,7 +418,7 @@ int play_sample(struct ctx *ctx, const struct cmd *cmd)
     do {
         num_read = fread(buffer, 1, size, ctx->file);
         if (num_read > 0) {
-            if (cmd->flags & PCM_MMAP)
+            if (cmd->flags & (PCM_MMAP | PCM_DMABUF))
                 ret = pcm_mmap_write(ctx->pcm, buffer, num_read);
             else
                 ret = pcm_writei(ctx->pcm, buffer,


### PR DESCRIPTION
This patch set is used to support Audio dmabuf, thus the audio buffer can be accessed based on using Linux kernel dmabuf mechanism; at the end we will export the audio buffer and attach to audio pcm device, the audio buffer will be accessed by using dmabuf file descriptor.          
                                                                        
In this patch series, patch 0001 is to provide APIs for wrapping Audio dmabuf ioctl, and it gives detailed info for the usage of every API; patch 0002 is to add new macro PCM_DMABUF as a new mode for pcm device, so pcm configuration and memory reading/writing flow can support dmabuf.
                                                                        
Patch 0003/0004 is mainly used to test Audio dmabuf with tinyplay program, patch 0003 firstly adds option '-M' to support the traditional mmaped method for audio playback, patch 0004 adds option '-B' for support dmabuf method for audio playback.                               
                                                                        
This patch series can be applied to Tinyalsa [1] and tested on Hikey960 with below two commands:                                                
                                                                        
  Playback with traditional memory mmaped:                              
    tinyplay --period-size 1024 --period-count 16 -c 2 --rate 48000 -M ~/example.wav                                            
                                                                        
  Playback with dmabuf:                                                 
    tinyplay --period-size 1024 --period-count 16 -c 2 --rate 48000 -B ~/example.wav                                            
                                                                        
[1] https://github.com/tinyalsa/tinyalsa