### PR TITLE
pcm: Set SW params.avail_min to period size

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -409,7 +409,7 @@ int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
     memset(&sparams, 0, sizeof(sparams));
     sparams.tstamp_mode = SNDRV_PCM_TSTAMP_ENABLE;
     sparams.period_step = 1;
-    sparams.avail_min = 1;
+    sparams.avail_min = config->period_size;
 
     if (!config->start_threshold) {
         if (pcm->flags & PCM_IN)


### PR DESCRIPTION
Using MMAP APIs, this parameter wake up application
when 'avail_min' samples are availables.

When audio processing expects exactly a full period size samples,
the default parameter to 1 burns CPU until the full period available.

Fix SW params.avail parameter to period size value.

Signed-off-by: Miguel GAIO <mgaio35@gmail.com>