### PR TITLE
tinyalsa: add plugin.h to install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ install:
 	install include/tinyalsa/mixer.h $(DESTDIR)$(INCDIR)/
 	install include/tinyalsa/asoundlib.h $(DESTDIR)$(INCDIR)/
 	install include/tinyalsa/version.h $(DESTDIR)$(INCDIR)/
+	install include/tinyalsa/plugin.h $(DESTDIR)$(INCDIR)/
 	$(MAKE) -C src install
 	$(MAKE) -C utils install
 	$(MAKE) -C doxygen install


### PR DESCRIPTION
Export plugin.h so that it can be used by tinyalsa
clients.

Signed-off-by: Rohit kumar <rohitkr@codeaurora.org>