### PR TITLE
pcm_hw_close: avoid SIGSEGV when pcm_hw_open fail

### DIFF
--- a/src/pcm_hw.c
+++ b/src/pcm_hw.c
@@ -97,6 +97,7 @@ static int pcm_hw_open(unsigned int card, unsigned int device,
         fd = open(fn, O_RDWR);
 
     if (fd < 0) {
+        free(hw_data);
         return fd;
     }
 


### PR DESCRIPTION
Prevent the call to pcm->ops-close() if pcm->ops->open() fail.
Fix memory leak in pcm_hw_open() in case of failure.

* thread #1, name = 'ut', stop reason = signal SIGSEGV: invalid address (fault address: 0x8)
    frame #0: 0x00007ffff7f863e8 libtinyalsa.so.1`pcm_hw_close(data=0x0000000000000000) at pcm_hw.c:61:21
   58  	{
   59  	    struct pcm_hw_data *hw_data = data;
   60
-> 61  	    if (hw_data->fd > 0)
   62  	        close(hw_data->fd);
   63
   64  	    free(hw_data);
(lldb) bt
* thread #1, name = 'ut', stop reason = signal SIGSEGV: invalid address (fault address: 0x8)
  * frame #0: 0x00007ffff7f863e8 libtinyalsa.so.1`pcm_hw_close(data=0x0000000000000000) at pcm_hw.c:61:21
    frame #1: 0x00007ffff7f8491c libtinyalsa.so.1`pcm_close(pcm=0x0000000000a9eba0) at pcm.c:820:5
    frame #2: 0x00007ffff7f84e0a libtinyalsa.so.1`pcm_open(card=128, device=0, flags=13, config=0x00007fffffffd000) at pcm.c:957:5

Signed-off-by: Miguel GAIO <mgaio35@gmail.com>