### PR TITLE
tinyalsa: include <sys/types.h> for ssize_t

### DIFF
--- a/include/tinyalsa/plugin.h
+++ b/include/tinyalsa/plugin.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #include <sound/asound.h>
 


### PR DESCRIPTION
ssize_t is defined in <sys/types.h>, see
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html

Add an include for it to avoid a compile error when building with musl:

```
../include/tinyalsa/plugin.h:184:5: error: expected specifier-qualifier-list before 'ssize_t'
  184 |     ssize_t (*read_event) (struct mixer_plugin *plugin,
      |     ^~~~~~~
```