### PR TITLE
tinyalsa: use strncpy instead of memcpy to copy string constant

### DIFF
--- a/src/mixer_plugin.c
+++ b/src/mixer_plugin.c
@@ -330,11 +330,11 @@ static int mixer_plug_get_card_info(struct mixer_plug_data *plug_data,
     /*TODO: Fill card_info here from snd-card-def */
     memset(card_info, 0, sizeof(*card_info));
     card_info->card = plug_data->card;
-    memcpy(card_info->id, "card_id", sizeof(card_info->id));
-    memcpy(card_info->driver, "mymixer-so-name", sizeof(card_info->driver));
-    memcpy(card_info->name, "card-name", sizeof(card_info->name));
-    memcpy(card_info->longname, "card-name", sizeof(card_info->longname));
-    memcpy(card_info->mixername, "mixer-name", sizeof(card_info->mixername));
+    strncpy((char*)card_info->id, "card_id", sizeof(card_info->id));
+    strncpy((char*)card_info->driver, "mymixer-so-name", sizeof(card_info->driver));
+    strncpy((char*)card_info->name, "card-name", sizeof(card_info->name));
+    strncpy((char*)card_info->longname, "card-name", sizeof(card_info->longname));
+    strncpy((char*)card_info->mixername, "mixer-name", sizeof(card_info->mixername));
 
     return 0;
 }

--- a/src/mixer_plugin.c
+++ b/src/mixer_plugin.c
@@ -330,11 +330,6 @@ static int mixer_plug_get_card_info(struct mixer_plug_data *plug_data,
     /*TODO: Fill card_info here from snd-card-def */
     memset(card_info, 0, sizeof(*card_info));
     card_info->card = plug_data->card;
-    strncpy((char*)card_info->id, "card_id", sizeof(card_info->id));
-    strncpy((char*)card_info->driver, "mymixer-so-name", sizeof(card_info->driver));
-    strncpy((char*)card_info->name, "card-name", sizeof(card_info->name));
-    strncpy((char*)card_info->longname, "card-name", sizeof(card_info->longname));
-    strncpy((char*)card_info->mixername, "mixer-name", sizeof(card_info->mixername));
 
     return 0;
 }


### PR DESCRIPTION
memcpy() is arguably wrong when copying these string constants.
The string constants will usually just be as long as necessary,
so we might copy some random memory behind it and eventually crash.

Use strncpy() instead to avoid copying characters after the null
terminator. For some reason the strings in snd_ctl_card_info use
unsigned chars, so we need a cast to char* to make it compile
unfortunately...

This fixes the following compile error on ppc64le:

```
In function 'mixer_plug_get_card_info',
    inlined from 'mixer_plug_ioctl' at mixer_plugin.c:371:15:
mixer_plugin.c:333:5: error: 'memcpy' forming offset [9, 16] is out of the bounds [0, 8] [-Werror=array-bounds]
  333 |     memcpy(card_info->id, "card_id", sizeof(card_info->id));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Not sure why that warning does not exist on other architectures.