### PR TITLE
Mixer event plugin update

### DIFF
--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -136,6 +136,7 @@ int mixer_ctl_get_range_min(const struct mixer_ctl *ctl);
 
 int mixer_ctl_get_range_max(const struct mixer_ctl *ctl);
 
+int mixer_consume_event(struct mixer *mixer);
 #if defined(__cplusplus)
 }  /* extern "C" */
 #endif

--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -35,7 +35,9 @@
 #ifndef TINYALSA_MIXER_H
 #define TINYALSA_MIXER_H
 
+#include <sys/time.h>
 #include <stddef.h>
+#include <sound/asound.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -135,6 +137,8 @@ int mixer_ctl_set_enum_by_string(struct mixer_ctl *ctl, const char *string);
 int mixer_ctl_get_range_min(const struct mixer_ctl *ctl);
 
 int mixer_ctl_get_range_max(const struct mixer_ctl *ctl);
+
+int mixer_read_event(struct mixer *mixer, struct snd_ctl_event *ev);
 
 int mixer_consume_event(struct mixer *mixer);
 #if defined(__cplusplus)

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -535,6 +535,27 @@ int mixer_wait_event(struct mixer *mixer, int timeout)
     }
 }
 
+/** Consume a mixer event.
+ * If mixer_subscribe_events has been called,
+ * mixer_wait_event will identify when a control value has changed.
+ * This function will clear a single event from the mixer so that
+ * further events can be alerted.
+ *
+ * @param mixer A mixer handle.
+ * @returns 0 on success.  -errno on failure.
+ * @ingroup libtinyalsa-mixer
+ */
+int mixer_consume_event(struct mixer *mixer) {
+    struct snd_ctl_event ev;
+    ssize_t count = read(mixer->fd, &ev, sizeof(ev));
+    // Exporting the actual event would require exposing snd_ctl_event
+    // via the header file, and all associated structs.
+    // The events generally tell you exactly which value changed,
+    // but reading values you're interested isn't hard and simplifies
+    // the interface greatly.
+    return (count >= 0) ? 0 : -errno;
+}
+
 static unsigned int mixer_grp_get_count(struct mixer_ctl_group *grp)
 {
     if (!grp)

--- a/src/mixer_hw.c
+++ b/src/mixer_hw.c
@@ -82,9 +82,18 @@ static int mixer_hw_ioctl(void *data, unsigned int cmd, ...)
     return ioctl(hw_data->fd, cmd, arg);
 }
 
+static ssize_t mixer_hw_read_event(void *data, struct snd_ctl_event *ev,
+                                   size_t size)
+{
+    struct mixer_hw_data *hw_data = data;
+
+    return read(hw_data->fd, ev, size);
+}
+
 static const struct mixer_ops mixer_hw_ops = {
     .close = mixer_hw_close,
     .ioctl = mixer_hw_ioctl,
+    .read_event = mixer_hw_read_event,
 };
 
 int mixer_hw_open(unsigned int card, void **data,

--- a/src/mixer_plugin.c
+++ b/src/mixer_plugin.c
@@ -137,8 +137,8 @@ static int mixer_plug_info_integer(struct snd_control *ctl,
 
 void mixer_plug_notifier_cb(struct mixer_plugin *plugin)
 {
-    eventfd_write(plugin->eventfd, 1);
     plugin->event_cnt++;
+    eventfd_write(plugin->eventfd, 1);
 }
 
 /* In consume_event/read, do not call eventfd_read until all events are read from list.


### PR DESCRIPTION
The PR consists of 3 changes:
1) Add mixer_consume_event() API: This was earlier introduced in google-origin branch. Change is directly ported from there (https://github.com/tinyalsa/tinyalsa/commit/b570106d92d72c4275f38f69723376af5db1e585 ).

2) Add mixer_read_event() and plugin support for mixer_consume_event() and mixer_read_event(). mixer_consume_event() just used to clear the event. However, there was no API to provide event details to the client. mixer_read_event() is updated version of mixer_consume_event() where the client can get the event details. This helps when the client polls for mixer event and receives multiple events. mixer_read_event() read and clear one event at a time. With this, plugin support for mixer_read_event() and mixer_consume_event() is also added.

3) Fix memory leak and mixer event handling : Poll Fd was not freed at the end of mixer_wait_event(). Freeing it to avoid memory leak. Also,  in mixer_plug_notifier_cb(), eventfd_write() was done before incrementing the event_cnt. eventfd_write() unblocks the poll in mixer_wait_event() and client can call mixer_read_event() to read/consume the event. However, if the  thread executing mixer_plug_notifier_cb() schedules out just after eventfd_write, then mixer_read_event() will eventually call mixer_plug_read_event() which will decrement event_cnt to negative (as event_cnt was not incremented at this time). To fix this, increment event_cnt first before calling eventfd_write() in mixer_plug_notifier_cb().