### PR TITLE
tinywavinfo: fix use of posix_memalign

### DIFF
--- a/utils/tinywavinfo.c
+++ b/utils/tinywavinfo.c
@@ -155,7 +155,7 @@ void analyse_sample(FILE *file, unsigned int channels, unsigned int bits,
 
     size = channels * byte_align * frame_size;
 
-    if (posix_memalign(&buffer, byte_align, size)) {
+    if (posix_memalign(&buffer, byte_align * sizeof(void *), size)) {
         fprintf(stderr, "Unable to allocate %d bytes\n", size);
         free(buffer);
         return;


### PR DESCRIPTION
In my previous commit switching to posix_memalign, I somehow didn't run into the issue this resolved when I used a test file, but later on I did, I guess I must have accidentally used a compiled tinywavinfo from before the change to test, anyway, here's a fix.