### PR TITLE
cmake: specify c99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.sh -s print
 
 project("TinyALSA" VERSION ${TINYALSA_VERSION} LANGUAGES C)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
 # Options
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(TINYALSA_USES_PLUGINS "Whether or not to build with plugin support" OFF)
@@ -38,7 +42,8 @@ target_include_directories("tinyalsa" PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 target_compile_definitions("tinyalsa" PRIVATE
-    $<$<BOOL:${TINYALSA_USES_PLUGINS}>:TINYALSA_USES_PLUGINS>)
+    $<$<BOOL:${TINYALSA_USES_PLUGINS}>:TINYALSA_USES_PLUGINS>
+    PUBLIC _POSIX_C_SOURCE=200809L)
 target_link_libraries("tinyalsa" PUBLIC ${CMAKE_DL_LIBS})
 
 # Examples
@@ -68,7 +73,7 @@ target_link_libraries("tinywavinfo" PRIVATE m)
 
 # Add C warning flags
 include(CheckCCompilerFlag)
-foreach(FLAG IN ITEMS -Wall -Wextra -Werror -Wfatal-errors)
+foreach(FLAG IN ITEMS -Wall -Wextra -Wpedantic -Werror -Wfatal-errors)
     string(TOUPPER "HAVE${FLAG}" HAVE_VAR)
     string(REPLACE "-" "_" HAVE_VAR "${HAVE_VAR}")
     check_c_compiler_flag("${FLAG}" "${HAVE_VAR}")

--- a/include/tinyalsa/plugin.h
+++ b/include/tinyalsa/plugin.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <time.h>
 
 #include <sound/asound.h>
 

--- a/src/snd_card_plugin.c
+++ b/src/snd_card_plugin.c
@@ -81,7 +81,7 @@ enum snd_node_type snd_utils_get_node_type(struct snd_node *node)
     node->ops->get_int(node->dev_node, "type", &val);
 
     return val;
-};
+}
 
 static int snd_utils_resolve_symbols(struct snd_node *node)
 {


### PR DESCRIPTION
Set standard to c99, require it, disable language extensions.
Define _POSIX_C_SOURCE to 200809L so time.h declares struct timespec.
Add -Wpedantic to find use of language extensions.
snd_card_plugin.c: remove one unnecessary ';' to make -Wpedantic work

This will prevent accidental usage of non-standard functions from the standard headers, and prevent use of language extensions. This won't prevent the use of needed linux-specific functions/types/macros from linux headers, such as sound/asound.h, as they don't gate things based on feature test macros like standard headers do.