### PR TITLE
tinywavinfo: replace use of pow()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ foreach(UTIL IN LISTS TINYALSA_UTILS)
     add_executable("${UTIL}" "utils/${UTIL}.c")
     target_link_libraries("${UTIL}" PRIVATE "tinyalsa")
 endforeach()
-target_link_libraries("tinywavinfo" PRIVATE m)
 
 # Add C warning flags
 include(CheckCCompilerFlag)

--- a/utils/tinywavinfo.c
+++ b/utils/tinywavinfo.c
@@ -31,7 +31,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <signal.h>
-#include <math.h>
 
 #define ID_RIFF 0x46464952
 #define ID_WAVE 0x45564157
@@ -162,7 +161,7 @@ void analyse_sample(FILE *file, unsigned int channels, unsigned int bits,
     else if (bits == 16)
         bytes_per_sample = 2;
 
-    normalization_factor = (float)pow(2.0, (bits-1));
+    normalization_factor = 1 << (bits-1);
 
     size = channels * bytes_per_sample * frame_size;
 


### PR DESCRIPTION
pow(2, x) is equivalent to 1 << x, use that to remove math library usage