### PR TITLE
Add build rules and documentation for tinywavinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@
 /utils/tinycap
 /utils/tinymix
 /utils/tinypcminfo
+/utils/tinywavinfo
 

--- a/Android.bp
+++ b/Android.bp
@@ -57,3 +57,9 @@ cc_binary {
     shared_libs: ["libtinyalsa"],
     cflags: ["-Werror"],
 }
+
+cc_binary {
+    name: "tinywavinfo",
+    srcs: ["utils/tinywavinfo.c"],
+    cflags: ["-Werror", "-lm"],
+}

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ sudo ldconfig
 
 TinyALSA is now available as a set of the following debian packages from [launchpad](https://launchpad.net/~taylorcholberton/+archive/ubuntu/tinyalsa):
 
-| Package Name:   | Description:                                        |
-|-----------------|-----------------------------------------------------|
-| tinyalsa        | Contains tinyplay, tinycap, tinymix and tinypcminfo |
-| libtinyalsa     | Contains the shared library                         |
-| libtinyalsa-dev | Contains the static library and header files        |
+| Package Name:   | Description:                                                      |
+|-----------------|-------------------------------------------------------------------|
+| tinyalsa        | Contains tinyplay, tinycap, tinymix, tinypcminfo, and tinywavinfo |
+| libtinyalsa     | Contains the shared library                                       |
+| libtinyalsa-dev | Contains the static library and header files                      |
 
 To install these packages, run the commands:
 
@@ -53,6 +53,7 @@ man tinyplay
 man tinycap
 man tinymix
 man tinypcminfo
+man tinywavinfo
 man libtinyalsa-pcm
 man libtinyalsa-mixer
 ```

--- a/debian/tinyalsa.install
+++ b/debian/tinyalsa.install
@@ -2,7 +2,9 @@ debian/tmp/usr/bin/tinyplay usr/bin/
 debian/tmp/usr/bin/tinycap usr/bin/
 debian/tmp/usr/bin/tinymix usr/bin/
 debian/tmp/usr/bin/tinypcminfo usr/bin/
+debian/tmp/usr/bin/tinywavinfo usr/bin/
 debian/tmp/usr/share/man/man1/tinyplay.1 usr/share/man/man1/
 debian/tmp/usr/share/man/man1/tinycap.1 usr/share/man/man1/
 debian/tmp/usr/share/man/man1/tinymix.1 usr/share/man/man1/
 debian/tmp/usr/share/man/man1/tinypcminfo.1 usr/share/man/man1/
+debian/tmp/usr/share/man/man1/tinywavinfo.1 usr/share/man/man1/

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -17,9 +17,11 @@ LDFLAGS += -pie
 VPATH = ../src:../include/tinyalsa
 
 .PHONY: all
-all: -ltinyalsa tinyplay tinycap tinymix tinypcminfo
+all: -ltinyalsa tinyplay tinycap tinymix tinypcminfo tinywavinfo
 
 tinyplay tinycap tinypcminfo tinymix: LDLIBS+=-ldl
+
+tinywavinfo: LDLIBS+=-lm
 
 tinyplay: tinyplay.o libtinyalsa.a
 
@@ -37,12 +39,17 @@ tinypcminfo: tinypcminfo.o libtinyalsa.a
 
 tinypcminfo.o: tinypcminfo.c pcm.h mixer.h asoundlib.h
 
+tinywavinfo: tinywavinfo.o
+
+tinywavinfo.o: tinywavinfo.c
+
 .PHONY: clean
 clean:
 	$(RM) tinyplay tinyplay.o
 	$(RM) tinycap tinycap.o
 	$(RM) tinymix tinymix.o
 	$(RM) tinypcminfo tinypcminfo.o
+	$(RM) tinywavinfo tinywavinfo.o
 
 .PHONY: install
 install: tinyplay tinycap tinymix tinypcminfo
@@ -51,9 +58,11 @@ install: tinyplay tinycap tinymix tinypcminfo
 	install tinycap $(DESTDIR)$(BINDIR)/
 	install tinymix $(DESTDIR)$(BINDIR)/
 	install tinypcminfo $(DESTDIR)$(BINDIR)/
+	install tinywavinfo $(DESTDIR)$(BINDIR)/
 	install -d $(DESTDIR)$(MANDIR)/man1
 	install tinyplay.1 $(DESTDIR)$(MANDIR)/man1/
 	install tinycap.1 $(DESTDIR)$(MANDIR)/man1/
 	install tinymix.1 $(DESTDIR)$(MANDIR)/man1/
 	install tinypcminfo.1 $(DESTDIR)$(MANDIR)/man1/
+	install tinywavinfo.1 $(DESTDIR)$(MANDIR)/man1/
 

--- a/utils/meson.build
+++ b/utils/meson.build
@@ -1,4 +1,4 @@
-utils = ['tinyplay', 'tinycap', 'tinymix', 'tinypcminfo']
+utils = ['tinyplay', 'tinycap', 'tinymix', 'tinypcminfo', 'tinywavinfo']
 
 foreach util : utils
   executable(util, '@0@.c'.format(util),

--- a/utils/tinywavinfo.1
+++ b/utils/tinywavinfo.1
@@ -1,0 +1,38 @@
+.TH TINYWAVINFO 1 "September 16, 2020" "tinywavinfo" "TinyALSA"
+
+.SH NAME
+tinywavinfo \- show information about a .wav file
+
+.SH SYNOPSIS
+.B tinywavinfo\fR \fIfile\fR
+
+.SH Description
+
+\fBtinywavinfo\fR shows information about the specified .wav file to standard output.
+In particular, it shows the channel count, sample rate in Hz, bits per sample,
+and average power of each channel in the file.
+At least one file must be specified.  If more than one file is given,
+information is only shown for the first file.
+Only signed 16-bit and 32-bit integer PCM formats are supported.
+There are no command line options.
+
+.SH EXAMPLES
+
+.TP
+\fBtinywavinfo output.wav\fR
+Shows information about a file called output.wav.
+
+.SH BUGS
+
+Please report bugs to https://github.com/tinyalsa/tinyalsa/issues.
+
+.SH SEE ALSO
+
+.BR tinycap(1),
+.BR tinyplay(1)
+
+.SH AUTHORS
+Jaydeep Dhole
+.P
+For a complete list of authors, visit the project page at https://github.com/tinyalsa/tinyalsa.
+


### PR DESCRIPTION
Note: only tested with Make, not the other build systems.