### PR TITLE
Fix error when building with -DTINYALSA_BUILD_UTILS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,10 @@ foreach(UTIL IN LISTS TINYALSA_UTILS)
     add_executable("${UTIL}" "utils/${UTIL}.c")
     target_link_libraries("${UTIL}" PRIVATE "tinyalsa")
 endforeach()
-target_link_libraries("tinywavinfo" PRIVATE m)
+
+if(TINYALSA_BUILD_UTILS)
+    target_link_libraries("tinywavinfo" PRIVATE m)
+endif()
 
 # Add C warning flags
 include(CheckCCompilerFlag)


### PR DESCRIPTION
Currently the `CMake` build fails if we disable building the utils.
```
CMake Error at CMakeLists.txt:72 (target_link_libraries):
  Cannot specify link libraries for target "tinywavinfo" which is not built
  by this project.


```