### PR TITLE
Fix pcm-write example

### DIFF
--- a/examples/pcm-writei.c
+++ b/examples/pcm-writei.c
@@ -74,7 +74,7 @@ static int write_frames(const void * frames, size_t byte_count){
     unsigned int frame_count = pcm_bytes_to_frames(pcm, byte_count);
 
     int err = pcm_writei(pcm, frames, frame_count);
-    if (err != 0) {
+    if (err < 0) {
       printf("error: %s\n", pcm_get_error(pcm));
     }
 


### PR DESCRIPTION
per pcm_writei: On success, this function returns the number of frames written; otherwise, a negative number.