### PR TITLE
Backward compatible for pcm_write() pcm_read()

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1511,7 +1511,13 @@ int pcm_readi(struct pcm *pcm, void *data, unsigned int frame_count)
  */
 int pcm_write(struct pcm *pcm, const void *data, unsigned int count)
 {
-    return pcm_writei(pcm, data, pcm_bytes_to_frames(pcm, count));
+    unsigned int requested_frames = pcm_bytes_to_frames(pcm, count);
+    int ret = pcm_writei(pcm, data, requested_frames);
+
+    if (ret < 0)
+        return ret;
+
+    return ((unsigned int )ret == requested_frames) ? 0 : -EIO;
 }
 
 /** Reads audio samples from PCM.
@@ -1527,7 +1533,13 @@ int pcm_write(struct pcm *pcm, const void *data, unsigned int count)
  */
 int pcm_read(struct pcm *pcm, void *data, unsigned int count)
 {
-    return pcm_readi(pcm, data, pcm_bytes_to_frames(pcm, count));
+    unsigned int requested_frames = pcm_bytes_to_frames(pcm, count);
+    int ret = pcm_readi(pcm, data, requested_frames);
+
+    if (ret < 0)
+        return ret;
+
+    return ((unsigned int )ret == requested_frames) ? 0 : -EIO;
 }
 
 /** Gets the delay of the PCM, in terms of frames.
@@ -1543,4 +1555,3 @@ long pcm_get_delay(struct pcm *pcm)
 
     return pcm->pcm_delay;
 }
-


### PR DESCRIPTION
Current return value of pcm_write()/pcm_read()
comes from pcm_writei()/pcm_readi() which is the
actual frames written/read. But the old pcm_write()
/pcm_read() just returns 0 on success and a nagative
value on error.

This change will keep the pcm_write()/pcm_read() as
the old behavior which has been already used by
many applications, and is also matching the comment
above each function.

Signed-off-by: Kui Wang <wangkuisuper@hotmail.com>