### PR TITLE
fix build breakage in Android

### DIFF
--- a/include/tinyalsa/attributes.h
+++ b/include/tinyalsa/attributes.h
@@ -6,7 +6,12 @@
  * when the library is being used incorrectly.
  * */
 
-#ifdef __GNUC__
+// FIXME: Disable the deprecated attribute in Android temporarily. pcm_read/write are marked as
+//   deprecated functions in the latest tinyalsa in GitHub. However, there are lots of libraries in
+//   Android using these functions and building with -Werror flags. Besides build breakage, the
+//   behavior and interface of the successors, pcm_readi/writei, are also changed. Once all have
+//   been cleaned up, we will enable this again.
+#if defined(__GNUC__) && !defined(ANDROID)
 
 /** Issues a warning when a function is being
  * used that is now deprecated.
@@ -20,7 +25,7 @@
  * */
 #define TINYALSA_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
-#else /* __GNUC__ */
+#else /* __GNUC__ && !ANDROID */
 
 /** This is just a placeholder for compilers
  * that aren't GCC or Clang.
@@ -34,6 +39,6 @@
  * */
 #define TINYALSA_WARN_UNUSED_RESULT
 
-#endif /* __GNUC__ */
+#endif /* __GNUC__ && !ANDROID */
 
 #endif /* TINYALSA_ATTRIBUTES_H */

--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -37,18 +37,33 @@
 
 #include <sys/time.h>
 #include <stddef.h>
-#include <sound/asound.h>
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
-/* TLV header size*/
-#define TLV_HEADER_SIZE sizeof(struct snd_ctl_tlv)
-
 struct mixer;
 
 struct mixer_ctl;
+
+// mixer_ctl_event is a mirroring structure of snd_ctl_event
+struct mixer_ctl_event {
+    int type;
+    union {
+        struct {
+            unsigned int mask;
+            struct {
+                unsigned int numid;
+                int iface;
+                unsigned int device;
+                unsigned int subdevice;
+                unsigned char name[44];
+                unsigned int index;
+            } id;
+        } element;
+        unsigned char data[60];
+    } data;
+};
 
 /** Mixer control type.
  * @ingroup libtinyalsa-mixer
@@ -138,7 +153,7 @@ int mixer_ctl_get_range_min(const struct mixer_ctl *ctl);
 
 int mixer_ctl_get_range_max(const struct mixer_ctl *ctl);
 
-int mixer_read_event(struct mixer *mixer, struct snd_ctl_event *ev);
+int mixer_read_event(struct mixer *mixer, struct mixer_ctl_event *event);
 
 int mixer_consume_event(struct mixer *mixer);
 #if defined(__cplusplus)

--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -221,6 +221,8 @@ struct pcm_config {
     /** The number of frames to overwrite the playback buffer when the playback underrun is greater
      * than the silence threshold */
     unsigned int silence_size;
+
+    unsigned int avail_min;
 };
 
 /** Enumeration of a PCM's hardware parameters.
@@ -360,6 +362,8 @@ int pcm_stop(struct pcm *pcm);
 int pcm_wait(struct pcm *pcm, int timeout);
 
 long pcm_get_delay(struct pcm *pcm);
+
+int pcm_ioctl(struct pcm *pcm, int code, ...) TINYALSA_DEPRECATED;
 
 #if defined(__cplusplus)
 }  /* extern "C" */

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -1750,3 +1750,21 @@ long pcm_get_delay(struct pcm *pcm)
 
     return pcm->pcm_delay;
 }
+
+// TODO: Currently in Android, there are some libraries using this function to control the driver.
+//   We should remove this function as soon as possible.
+int pcm_ioctl(struct pcm *pcm, int request, ...)
+{
+    va_list ap;
+    void * arg;
+
+    if (!pcm_is_ready(pcm))
+        return -1;
+
+    va_start(ap, request);
+    arg = va_arg(ap, void *);
+    va_end(ap);
+
+    // FIXME Does not handle plugins
+    return ioctl(pcm->fd, request, arg);
+}


### PR DESCRIPTION
1. Add a missing field and a function
2. Disable the deprecated attribute in Android temporarily to allow us to use "pcm_read/write" which are deprecated upstream
3. Remove an unused define and an include in mixer.h
4. Add mixer_ctl_event and copy the snd_ctl_event to mixer_ctl_event
5. Add pcm_ioctl function and mark as deprecated function