### PR TITLE
Sync AOSP: [LSC] Add LOCAL_LICENSE_KINDS to external/tinyalsa_new

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,33 @@
+package {
+    default_applicable_licenses: ["external_tinyalsa_new_license"],
+}
+
+// Added automatically by a large-scale-change that took the approach of
+// 'apply every license found to every target'. While this makes sure we respect
+// every license restriction, it may not be entirely correct.
+//
+// e.g. GPL in an MIT project might only apply to the contrib/ directory.
+//
+// Please consider splitting the single license below into multiple licenses,
+// taking care not to lose any license_kind information, and overriding the
+// default license using the 'licenses: [...]' property on targets as needed.
+//
+// For unused files, consider creating a 'fileGroup' with "//visibility:private"
+// to attach the license to, and including a comment whether the files may be
+// used in the current project.
+// See: http://go/android-license-faq
+license {
+    name: "external_tinyalsa_new_license",
+    visibility: [":__subpackages__"],
+    license_kinds: [
+        "SPDX-license-identifier-BSD",
+        "SPDX-license-identifier-Unlicense",
+    ],
+    license_text: [
+        "NOTICE",
+    ],
+}
+
 cc_library {
     name: "libtinyalsav2",
     host_supported: true,


### PR DESCRIPTION
https://android.googlesource.com/platform/external/tinyalsa_new/+/535e6ea3edcb6e119d465073facc3b2a338bdcb1

[LSC] Add LOCAL_LICENSE_KINDS to external/tinyalsa_new

Added SPDX-license-identifier-BSD SPDX-license-identifier-Unlicense to:
  Android.bp

Bug: 68860345
Bug: 151177513
Bug: 151953481

Test: m all

Exempt-From-Owner-Approval: janitorial work
Change-Id: I21fe326f57f35b252901cf1423c4af149694fb51