### PR TITLE
force pcm_open to open device with the non-blocking flag

### DIFF
--- a/tests/include/pcm_test_device.h
+++ b/tests/include/pcm_test_device.h
@@ -29,6 +29,8 @@
 #ifndef TINYALSA_TESTS_PCM_TEST_H_
 #define TINYALSA_TESTS_PCM_TEST_H_
 
+#include "tinyalsa/pcm.h"
+
 namespace tinyalsa {
 namespace testing {
 
@@ -44,9 +46,25 @@ namespace testing {
 #define TEST_LOOPBACK_CAPTURE_DEVICE 1
 #endif
 
-constexpr unsigned int kLoopbackCard = TEST_LOOPBACK_CARD;
-constexpr unsigned int kLoopbackPlaybackDevice = TEST_LOOPBACK_PLAYBACK_DEVICE;
-constexpr unsigned int kLoopbackCaptureDevice = TEST_LOOPBACK_CAPTURE_DEVICE;
+static constexpr unsigned int kLoopbackCard = TEST_LOOPBACK_CARD;
+static constexpr unsigned int kLoopbackPlaybackDevice = TEST_LOOPBACK_PLAYBACK_DEVICE;
+static constexpr unsigned int kLoopbackCaptureDevice = TEST_LOOPBACK_CAPTURE_DEVICE;
+
+static constexpr unsigned int kDefaultChannels = 2;
+static constexpr unsigned int kDefaultSamplingRate = 48000;
+static constexpr unsigned int kDefaultPeriodSize = 1024;
+static constexpr unsigned int kDefaultPeriodCount = 3;
+static constexpr pcm_config kDefaultConfig = {
+    .channels = kDefaultChannels,
+    .rate = kDefaultSamplingRate,
+    .period_size = kDefaultPeriodSize,
+    .period_count = kDefaultPeriodCount,
+    .format = PCM_FORMAT_S16_LE,
+    .start_threshold = kDefaultPeriodSize,
+    .stop_threshold = kDefaultPeriodSize * kDefaultPeriodCount,
+    .silence_threshold = 0,
+    .silence_size = 0,
+};
 
 } // namespace testing
 } // namespace tinyalsa

--- a/tests/src/pcm_loopback_test.cc
+++ b/tests/src/pcm_loopback_test.cc
@@ -193,10 +193,6 @@ class PcmLoopbackTest : public ::testing::Test {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    static constexpr unsigned int kDefaultChannels = 2;
-    static constexpr unsigned int kDefaultSamplingRate = 48000;
-    static constexpr unsigned int kDefaultPeriodSize = 1024;
-    static constexpr unsigned int kDefaultPeriodCount = 3;
     static constexpr unsigned int kDefaultPeriodTimeInMs =
             kDefaultPeriodSize * 1000 / kDefaultSamplingRate;
     static constexpr pcm_format kPcmForamt = F::kFormat;
@@ -212,10 +208,6 @@ using Formats = ::testing::Types<S16bitlePcmFormat, FloatPcmFormat>;
 TYPED_TEST_SUITE(PcmLoopbackTest, Formats);
 
 TYPED_TEST(PcmLoopbackTest, Loopback) {
-    static constexpr unsigned int kDefaultChannels = this->kDefaultChannels;
-    static constexpr unsigned int kDefaultSamplingRate = this->kDefaultSamplingRate;
-    static constexpr unsigned int kDefaultPeriodSize = this->kDefaultPeriodSize;
-    // static constexpr unsigned int kDefaultPeriodCount = this->kDefaultPeriodCount;
     static constexpr unsigned int kDefaultPeriodTimeInMs = this->kDefaultPeriodTimeInMs;
     static constexpr pcm_format kPcmForamt = this->kPcmForamt;
     pcm *pcm_in = this->pcm_in;


### PR DESCRIPTION
When a client opens a PCM device whose substreams are all occupied without the non-blocking flag, the open function would be blocked in the kernel until the previous opened ones are closed. This would cause deadlock if they try to hold the same lock. Most of the ALSA PCM drivers on embedded systems are implemented with the ALSA SOC framework. Each PCM device has only one substream. This problem would happen frequently. To force pcm_open to open PCM devices with non-blocking flag is beneficial to resolve this problem. It returns the control to clients to try again later.

The reason why we don't call pcm_open with PCM_NONBLOCK is that the PCM_NONBLOCK also affects the read and write behaviors.

I also add a test case to test whether the pcm_open would be blocked.