### PR TITLE
fix the zero fd closing problem

### DIFF
--- a/src/pcm_hw.c
+++ b/src/pcm_hw.c
@@ -50,7 +50,7 @@ struct pcm_hw_data {
     /** Device number for the pcm device */
     unsigned int device;
     /** File descriptor to the pcm device file node */
-    unsigned int fd;
+    int fd;
     /** Pointer to the pcm node from snd card definiton */
     struct snd_node *node;
 };
@@ -59,7 +59,7 @@ static void pcm_hw_close(void *data)
 {
     struct pcm_hw_data *hw_data = data;
 
-    if (hw_data->fd > 0)
+    if (hw_data->fd >= 0)
         close(hw_data->fd);
 
     free(hw_data);


### PR DESCRIPTION
The pcm_hw_close refused to close the zero fd. Remove the condition to close the zero fd.