### PR TITLE
meson: add attributes.h and plugin.h public headers

### DIFF
--- a/include/tinyalsa/meson.build
+++ b/include/tinyalsa/meson.build
@@ -1,9 +1,11 @@
 tinyalsa_headers = [
   'asoundlib.h',
+  'attributes.h',
   'interval.h',
   'limits.h',
   'mixer.h',
   'pcm.h',
+  'plugin.h',
   'version.h'
 ]
 


### PR DESCRIPTION
This adds the missing public headers that are installed with the tinyalsa CMake target that is set in `CMakeLists.txt`.  
Working as expected, tested while packaging tinyalsa as an Arch Linux package.

Closes #215.