### PR TITLE
mixer: fix index underflow when index=0

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -732,9 +732,13 @@ struct mixer_ctl *mixer_get_ctl_by_name_and_index(struct mixer *mixer,
         ctl = grp->ctl;
 
         for (n = 0; n < grp->count; n++)
-            if (!strcmp(name, (char*) ctl[n].info.id.name))
-                if (index-- == 0)
+            if (!strcmp(name, (char*) ctl[n].info.id.name)) {
+                if (index == 0) {
                     return ctl + n;
+                } else {
+                    index--;
+                }
+            }
     }
 
 #ifdef TINYALSA_USES_PLUGINS
@@ -743,9 +747,13 @@ struct mixer_ctl *mixer_get_ctl_by_name_and_index(struct mixer *mixer,
         ctl = grp->ctl;
 
         for (n = 0; n < grp->count; n++)
-            if (!strcmp(name, (char*) ctl[n].info.id.name))
-                if (index-- == 0)
+            if (!strcmp(name, (char*) ctl[n].info.id.name)) {
+                if (index == 0) {
                     return ctl + n;
+                } else {
+                    index--;
+                }
+            }
     }
 #endif
     return NULL;


### PR DESCRIPTION
In mixer_get_ctl_by_name_and_index(), the post-fix decrement means that the index will be decremented after the comparison, but before the return, leading to an unsigned integer underflow.

The error is caught on Android platforms, presumably using `-fsanitize=integer`. When built without the option the underflow would still occur but given the function returns immediately afterwards there would be no side effects.