### PR TITLE
fix strncpy warnings

### DIFF
--- a/src/mixer_plugin.c
+++ b/src/mixer_plugin.c
@@ -82,7 +82,7 @@ static int mixer_plug_get_elem_id(struct mixer_plug_data *plug_data,
     id->iface = ctl->iface;
 
     strncpy((char *)id->name, (char *)ctl->name,
-            sizeof(id->name));
+            sizeof(id->name) - 1);
 
     return 0;
 }
@@ -100,7 +100,7 @@ static int mixer_plug_info_enum(struct snd_control *ctl,
 
     strncpy(einfo->value.enumerated.name,
             val->texts[einfo->value.enumerated.item],
-            sizeof(einfo->value.enumerated.name));
+            sizeof(einfo->value.enumerated.name) - 1);
 
     return 0;
 }

--- a/src/pcm_plugin.c
+++ b/src/pcm_plugin.c
@@ -153,9 +153,9 @@ static int pcm_plug_info(struct pcm_plug_data *plug_data,
         return ret;
     }
 
-    strncpy((char *)info->id, name, sizeof(info->id));
-    strncpy((char *)info->name, name, sizeof(info->name));
-    strncpy((char *)info->subname, name, sizeof(info->subname));
+    strncpy((char *)info->id, name, sizeof(info->id) - 1);
+    strncpy((char *)info->name, name, sizeof(info->name) - 1);
+    strncpy((char *)info->subname, name, sizeof(info->subname) - 1);
 
     info->subdevices_count = 1;
 


### PR DESCRIPTION
Since gcc 9.0, checking strncpy is more strict.

Please refer https://github.com/tinyalsa/tinyalsa/issues/219.