### PR TITLE
fix strncpy potential bug

### DIFF
--- a/src/mixer_plugin.c
+++ b/src/mixer_plugin.c
@@ -83,6 +83,7 @@ static int mixer_plug_get_elem_id(struct mixer_plug_data *plug_data,
 
     strncpy((char *)id->name, (char *)ctl->name,
             sizeof(id->name) - 1);
+    ((char *)id->name)[sizeof(id->name) - 1] = '\0';
 
     return 0;
 }
@@ -101,6 +102,7 @@ static int mixer_plug_info_enum(struct snd_control *ctl,
     strncpy(einfo->value.enumerated.name,
             val->texts[einfo->value.enumerated.item],
             sizeof(einfo->value.enumerated.name) - 1);
+    einfo->value.enumerated.name[sizeof(einfo->value.enumerated.name) - 1] = '\0';
 
     return 0;
 }

--- a/src/pcm_plugin.c
+++ b/src/pcm_plugin.c
@@ -154,8 +154,11 @@ static int pcm_plug_info(struct pcm_plug_data *plug_data,
     }
 
     strncpy((char *)info->id, name, sizeof(info->id) - 1);
+    ((char *)info->id)[sizeof(info->id) - 1] = '\0';
     strncpy((char *)info->name, name, sizeof(info->name) - 1);
+    ((char *)info->name)[sizeof(info->name) - 1] = '\0';
     strncpy((char *)info->subname, name, sizeof(info->subname) - 1);
+    ((char *)info->subname)[sizeof(info->subname) - 1] = '\0';
 
     info->subdevices_count = 1;
 


### PR DESCRIPTION
Sorry for my previous imcomplete PR.https://github.com/tinyalsa/tinyalsa/pull/220

I think strncpy in tinyalsa has potential bug.
(please refer  https://stackoverflow.com/questions/21210293/problems-with-strncpy-and-how-to-fix-it)

This PR is to insert null at end of strncpy target array.