### PR TITLE
Fix a type issue and a mixer control issue.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,5 +3,5 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "googletest",
     remote = "https://github.com/google/googletest",
-    branch = "master",
+    branch = "main",
 )

--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -217,16 +217,16 @@ struct pcm_config {
      * silence_size      : 0
      */
     /** The minimum number of frames required to start the PCM */
-    unsigned int start_threshold;
+    unsigned long start_threshold;
     /** The minimum number of frames required to stop the PCM */
-    unsigned int stop_threshold;
+    unsigned long stop_threshold;
     /** The minimum number of frames to silence the PCM */
-    unsigned int silence_threshold;
+    unsigned long silence_threshold;
     /** The number of frames to overwrite the playback buffer when the playback underrun is greater
      * than the silence threshold */
-    unsigned int silence_size;
+    unsigned long silence_size;
 
-    unsigned int avail_min;
+    unsigned long avail_min;
 };
 
 /** Enumeration of a PCM's hardware parameters.

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -1047,6 +1047,9 @@ int mixer_ctl_get_array(const struct mixer_ctl *ctl, void *array, size_t count)
         }
 
     case SNDRV_CTL_ELEM_TYPE_IEC958:
+        ret = grp->ops->ioctl(grp->data, SNDRV_CTL_IOCTL_ELEM_READ, &ev);
+        if (ret < 0)
+            return ret;
         size = sizeof(ev.value.iec958);
         source = &ev.value.iec958;
         break;


### PR DESCRIPTION
1. Since unsigned int and unsigned long are 4 and 8 bytes on LP64 machine, respectively, the type mismatching causes problems when setting up. Fix the type mismatching between pcm_config and snd_pcm_sw_params.
2. Add the missing ioctl to get the IEC958 data.
3. Fix the branch name of googletest.