### PR TITLE
include time.h before asound.h

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -55,6 +55,7 @@
 #define __user
 #endif
 
+#include <time.h>
 #include <sound/asound.h>
 
 #include <tinyalsa/mixer.h>

--- a/src/mixer_hw.c
+++ b/src/mixer_hw.c
@@ -42,6 +42,7 @@
 #include <sys/ioctl.h>
 
 #include <linux/ioctl.h>
+#include <time.h>
 #include <sound/asound.h>
 
 #include "mixer_io.h"

--- a/src/pcm_hw.c
+++ b/src/pcm_hw.c
@@ -41,6 +41,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <linux/ioctl.h>
+#include <time.h>
 #include <sound/asound.h>
 #include <tinyalsa/asoundlib.h>
 

--- a/src/pcm_plugin.c
+++ b/src/pcm_plugin.c
@@ -40,6 +40,7 @@
 
 #include <sys/ioctl.h>
 #include <linux/ioctl.h>
+#include <time.h>
 #include <sound/asound.h>
 #include <tinyalsa/asoundlib.h>
 #include <tinyalsa/plugin.h>


### PR DESCRIPTION
Include time.h before asound.h to avoid the following build failure on musl that was already fixed a long time with tinyalsa@c8333f8 but reappeared on version 2.0.0:

```
In file included from ../src/pcm_hw.c:42:
/home/peko/autobuild/instance-1/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/sound/asound.h:444:18: error: field 'trigger_tstamp' has incomplete type
  444 |  struct timespec trigger_tstamp; /* time when stream was started/stopped/paused */
      |                  ^~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/a75e23dc585bd071f4d65face5489ed6ac22edbe

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>