### PR TITLE
Update pcm boundary to 64-bit

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -305,7 +305,7 @@ struct pcm {
     /** Size of the buffer */
     unsigned int buffer_size;
     /** The boundary for ring buffer pointers */
-    unsigned int boundary;
+    unsigned long boundary;
     /** Description of the last error that occured */
     char error[PCM_ERROR_MAX];
     /** Configuration that was passed to @ref pcm_open */
@@ -529,7 +529,7 @@ int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
     sparams.silence_threshold = config->silence_threshold;
     pcm->boundary = sparams.boundary = pcm->buffer_size;
 
-    while (pcm->boundary * 2 <= INT_MAX - pcm->buffer_size)
+    while (pcm->boundary * 2 <= LONG_MAX - (unsigned long)pcm->buffer_size)
         pcm->boundary *= 2;
 
     if (pcm->ops->ioctl(pcm->data, SNDRV_PCM_IOCTL_SW_PARAMS, &sparams)) {


### PR DESCRIPTION
Since linux kernel use 64-bit boundary calculation,
hw_ptr and appl_ptr will be out of sync once they
reach the current 32-bit boundary.

Note that alsa-lib also use 64-bit in boundary calculation:
https://github.com/alsa-project/alsa-lib/blob/7f2d6c3aac3505ceee4b0d3e8b3ca423ce29b070/src/pcm/pcm_params.c#L2338