### PR TITLE
mmap support in tinycap

### DIFF
--- a/utils/tinycap.1
+++ b/utils/tinycap.1
@@ -24,6 +24,11 @@ Device number of the PCM.
 The default is 0.
 
 .TP
+\fB\-M\fR
+Use memory-mapped I/O method.
+If this option is not specified, then read and write I/O method will be used.
+
+.TP
 \fB\-c\fR \fIchannels\fR
 Number of channels the PCM will have.
 The default is 2.


### PR DESCRIPTION
This pull request implements mmap (-M option) support in the tinycap utility. This is necessary for some hardware to work (e.g. Plugable HDMI capture card with USB ID 1bcf:2c99). This patch is simple, it just enables PCM_MMAP flag for pcm_open() function in libtinyalsa, the actual functionality is already implemented in the library. My testing has confirmed that it does work with the aforementioned hardware after applying the patch.