### PR TITLE
tinyplay: fix playback of 24-bit and 8-bit pcm

### DIFF
--- a/utils/tinyplay.c
+++ b/utils/tinyplay.c
@@ -112,7 +112,7 @@ static bool is_wave_file(const char *filetype)
     return filetype != NULL && strcmp(filetype, "wav") == 0;
 }
 
-static bool signed_pcm_bits_to_format(int bits)
+static enum pcm_format signed_pcm_bits_to_format(int bits)
 {
     switch (bits) {
     case 8:


### PR DESCRIPTION
The bits-to-format function returned bool, which happened to work for PCM_FORMAT_S16_LE (0) and PCM_FORMAT_S32_LE (1). However, all other formats were incorrectly mapped to PCM_FORMAT_S32_LE. Return enum pcm_format instead.