### PR TITLE
Chmap mixer support

### DIFF
--- a/include/tinyalsa/mixer.h
+++ b/include/tinyalsa/mixer.h
@@ -103,6 +103,10 @@ struct mixer_ctl *mixer_get_ctl(struct mixer *mixer, unsigned int id);
 
 struct mixer_ctl *mixer_get_ctl_by_name(struct mixer *mixer, const char *name);
 
+struct mixer_ctl *mixer_get_ctl_by_name_and_device(struct mixer *mixer,
+                                                   const char *name,
+                                                   unsigned int device);
+
 struct mixer_ctl *mixer_get_ctl_by_name_and_index(struct mixer *mixer,
                                                   const char *name,
                                                   unsigned int index);
@@ -152,6 +156,8 @@ int mixer_ctl_set_enum_by_string(struct mixer_ctl *ctl, const char *string);
 int mixer_ctl_get_range_min(const struct mixer_ctl *ctl);
 
 int mixer_ctl_get_range_max(const struct mixer_ctl *ctl);
+
+unsigned int mixer_ctl_get_device(const struct mixer_ctl *ctl);
 
 int mixer_read_event(struct mixer *mixer, struct mixer_ctl_event *event);
 

--- a/utils/tinymix.c
+++ b/utils/tinymix.c
@@ -201,7 +201,7 @@ static void list_controls(struct mixer *mixer, int print_all)
 {
     struct mixer_ctl *ctl;
     const char *name, *type;
-    unsigned int num_ctls, num_values;
+    unsigned int num_ctls, num_values, device;
     unsigned int i;
 
     num_ctls = mixer_get_num_ctls(mixer);
@@ -209,9 +209,9 @@ static void list_controls(struct mixer *mixer, int print_all)
     printf("Number of controls: %u\n", num_ctls);
 
     if (print_all)
-        printf("ctl\ttype\tnum\t%-40svalue\n", "name");
+        printf("ctl\ttype\tnum\t%-40s\tdevice\tvalue\n", "name");
     else
-        printf("ctl\ttype\tnum\t%-40s\n", "name");
+        printf("ctl\ttype\tnum\t%-40s\tdevice\n", "name");
 
     for (i = 0; i < num_ctls; i++) {
         ctl = mixer_get_ctl(mixer, i);
@@ -219,7 +219,8 @@ static void list_controls(struct mixer *mixer, int print_all)
         name = mixer_ctl_get_name(ctl);
         type = mixer_ctl_get_type_string(ctl);
         num_values = mixer_ctl_get_num_values(ctl);
-        printf("%u\t%s\t%u\t%-40s", i, type, num_values, name);
+        device = mixer_ctl_get_dev_num(ctl);
+        printf("%u\t%s\t%u\t%-40s\t%u", i, type, num_values, name, device);
         if (print_all)
             print_control_values(ctl);
         printf("\n");


### PR DESCRIPTION
There can be multiple chmap mixer control in a platform (e.g. - Playback Channel map / Capture Channel map) for each pcm devices. Tinyalsa does not provide an api to get the mixer_ctl handle based on combination of mixer control name and pcm_device id. This adds support for getting mixer_ctl handle for such cases.