### PR TITLE
fix race condition between plugin event read/write

### DIFF
--- a/include/tinyalsa/plugin.h
+++ b/include/tinyalsa/plugin.h
@@ -218,7 +218,7 @@ struct mixer_plugin {
 
     int eventfd;
     int subscribed;
-    int event_cnt;
+    volatile int event_cnt;
 
     struct snd_control *controls;
     unsigned int num_controls;


### PR DESCRIPTION
Corner case observed when new event coming just after old events read, eventfd counter is reset to 0 due to old event reading even though a new event just increase eventfd counter by 1. This will cause delay of event notification.
Use flag EFD_SEMAPHORE when creating eventfd to decrease eventfd counter by actual event numbers getting read.