### PR TITLE
fix race condition between plugin event read/write

### DIFF
--- a/include/tinyalsa/plugin.h
+++ b/include/tinyalsa/plugin.h
@@ -33,6 +33,7 @@
 #include <poll.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <pthread.h>
 #include <sys/types.h>
 #include <time.h>
 
@@ -222,6 +223,7 @@ struct mixer_plugin {
 
     struct snd_control *controls;
     unsigned int num_controls;
+    pthread_mutex_t mutex;
 };
 
 struct snd_value_enum {


### PR DESCRIPTION
Corner case observed when new event coming just after old events read, eventfd counter is reset to 0 due to old event reading even though a new event just increase eventfd counter by 1. This will cause delay of event notification.
Use flag EFD_SEMAPHORE when creating eventfd to decrease eventfd counter by actual event numbers getting read.