### PR TITLE
Fixes bugs and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_C_EXTENSIONS OFF)
 
 # Options
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-option(TINYALSA_USES_PLUGINS "Whether or not to build with plugin support" OFF)
+option(TINYALSA_USES_PLUGINS "Whether or not to build with plugin support" ON)
 option(TINYALSA_BUILD_EXAMPLES "Build examples" ON)
 option(TINYALSA_BUILD_UTILS "Build utility tools" ON)
 

--- a/src/pcm_plugin.c
+++ b/src/pcm_plugin.c
@@ -563,7 +563,8 @@ static int pcm_plug_readi_frames(struct pcm_plug_data *plug_data,
 {
     struct pcm_plugin *plugin = plug_data->plugin;
 
-    if (plugin->state != PCM_PLUG_STATE_RUNNING)
+    if (plugin->state != PCM_PLUG_STATE_PREPARED &&
+        plugin->state != PCM_PLUG_STATE_RUNNING)
         return -EBADFD;
 
     return plug_data->ops->readi_frames(plugin, x);

--- a/utils/tinywavinfo.c
+++ b/utils/tinywavinfo.c
@@ -149,7 +149,7 @@ void analyse_sample(FILE *file, unsigned int channels, unsigned int bits,
     void *buffer;
     int size;
     int num_read;
-    int i;
+    unsigned int i;
     unsigned int ch;
     int frame_size = 1024;
     unsigned int bytes_per_sample = 0;


### PR DESCRIPTION
There are three commits I made:
* Fixes a bug where pcm_start is not called while running tinycap if PCM_MMAP flag is not set.
* Fixes a warning where comparison of integer expressions of different signedness
* Enable TinyAlsa plugin support by default