### PR TITLE
meson: add option to enable/disable plugin support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,10 @@ cc = meson.get_compiler('c')
 # Dependency on libdl
 dl_dep = cc.find_library('dl')
 
+if get_option('tinyalsa_uses_plugins')
+    add_project_arguments('-DTINYALSA_USES_PLUGINS', language: 'c')
+endif
+
 tinyalsa = library('tinyalsa',
   'src/mixer.c', 'src/pcm.c', 'src/pcm_hw.c', 'src/pcm_plugin.c', 'src/snd_card_plugin.c', 'src/mixer_hw.c', 'src/mixer_plugin.c',
   include_directories: tinyalsa_includes,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,5 @@ option('examples', type: 'feature', value: 'auto', yield: true,
   description : 'Build examples')
 option('utils', type: 'feature', value: 'auto', yield: true,
   description : 'Build utility tools')
+option('tinyalsa_uses_plugins', type: 'boolean', value: true,
+  description : 'Enable plugin support')


### PR DESCRIPTION
Default is enabled to support Tinyalsa plugin.

ref:https://github.com/tinyalsa/tinyalsa/pull/261