### PR TITLE
Tinyalsa utilities output formatting and preventing seg fault.

### DIFF
--- a/utils/tinymix.c
+++ b/utils/tinymix.c
@@ -220,7 +220,7 @@ static void list_controls(struct mixer *mixer, int print_all)
         type = mixer_ctl_get_type_string(ctl);
         num_values = mixer_ctl_get_num_values(ctl);
         device = mixer_ctl_get_device(ctl);
-        printf("%u\t%s\t%u\t%-40s\t%u", i, type, num_values, name, device);
+        printf("%u\t%s\t%u\t%-40s\t%u\t", i, type, num_values, name, device);
         if (print_all)
             print_control_values(ctl);
         printf("\n");

--- a/utils/tinyplay.c
+++ b/utils/tinyplay.c
@@ -184,14 +184,14 @@ static int ctx_init(struct ctx* ctx, struct cmd *cmd)
         ctx->file = stdin;
     } else {
         ctx->file = fopen(cmd->filename, "rb");
+        if (ctx->file == NULL) {
+            fprintf(stderr, "failed to open '%s'\n", cmd->filename);
+            return -1;
+        }
+
         fseek(ctx->file, 0L, SEEK_END);
         ctx->file_size = ftell(ctx->file);
         fseek(ctx->file, 0L, SEEK_SET);
-    }
-
-    if (ctx->file == NULL) {
-        fprintf(stderr, "failed to open '%s'\n", cmd->filename);
-        return -1;
     }
 
     if (is_wave_file(cmd->filetype)) {


### PR DESCRIPTION
tinymix contents
ctl	type	num	name                                    	device	value
0	BOOL	1	Master Playback Switch                  	0On
1	INT	2	Master Playback Volume                  	049, 49 (range 0->63)
...
device number and value require separation
tab character added to printf statement.

tinyplay  wrongname.wav
Segmentation fault         (core dumped) tinyplay wrongname.wav

Test file descriptor for null value before (not after) fseek is called.