### PR TITLE
tinyalsa: Add pcm_set_sw_config

### DIFF
--- a/include/tinyalsa/pcm.h
+++ b/include/tinyalsa/pcm.h
@@ -319,6 +319,8 @@ const char *pcm_get_error(const struct pcm *pcm);
 
 int pcm_set_config(struct pcm *pcm, const struct pcm_config *config);
 
+int pcm_set_sw_config(struct pcm *pcm, const struct pcm_config *config);
+
 unsigned int pcm_format_to_bits(enum pcm_format format);
 
 unsigned int pcm_get_buffer_size(const struct pcm *pcm);

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -497,39 +497,71 @@ int pcm_set_config(struct pcm *pcm, const struct pcm_config *config)
         }
     }
 
+    if (pcm_set_sw_config(pcm, config) < 0) {
+        int errno_copy = errno;
+        oops(pcm, errno, "cannot set sw params");
+        return -errno_copy;
+    }
+
+    return 0;
+}
+
+/** Sets the PCM software configuration.
+ * @param pcm A PCM handle.
+ * @param config The configuration to use for software parameters of the PCM.
+ * @returns Zero on success, a negative errno value on failure.
+ * @ingroup libtinyalsa-pcm
+ */
+int pcm_set_sw_config(struct pcm *pcm, const struct pcm_config *config)
+{
+    if (!pcm || !pcm_is_ready(pcm) || !config)
+        return -EFAULT;
+
     struct snd_pcm_sw_params sparams;
     memset(&sparams, 0, sizeof(sparams));
     sparams.tstamp_mode = SNDRV_PCM_TSTAMP_ENABLE;
     sparams.period_step = 1;
-    if (!pcm->config.avail_min) {
-        pcm->config.avail_min = pcm->config.period_size;
+
+    if (!config->avail_min) {
+        if (!pcm->config.avail_min) {
+            pcm->config.avail_min = pcm->config.period_size;
+        }
+        sparams.avail_min = pcm->config.avail_min;
+    } else {
+        pcm->config.avail_min = sparams.avail_min = config->avail_min;
+        if (pcm->mmap_control)
+            pcm->mmap_control->avail_min = pcm->config.avail_min;
     }
-    sparams.avail_min = pcm->config.avail_min;
 
     if (!config->start_threshold) {
         if (pcm->flags & PCM_IN)
             pcm->config.start_threshold = sparams.start_threshold = 1;
         else
             pcm->config.start_threshold = sparams.start_threshold =
-                config->period_count * config->period_size / 2;
-    } else
-        sparams.start_threshold = config->start_threshold;
+                pcm->config.period_count * pcm->config.period_size / 2;
+    } else {
+        pcm->config.start_threshold = sparams.start_threshold =
+            config->start_threshold;
+    }
 
     /* pick a high stop threshold - todo: does this need further tuning */
     if (!config->stop_threshold) {
         if (pcm->flags & PCM_IN)
             pcm->config.stop_threshold = sparams.stop_threshold =
-                config->period_count * config->period_size * 10;
+                pcm->config.period_count * pcm->config.period_size * 10;
         else
             pcm->config.stop_threshold = sparams.stop_threshold =
-                config->period_count * config->period_size;
+                pcm->config.period_count * pcm->config.period_size;
+    } else {
+        pcm->config.stop_threshold = sparams.stop_threshold =
+            config->stop_threshold;
     }
-    else
-        sparams.stop_threshold = config->stop_threshold;
 
-    sparams.xfer_align = config->period_size / 2; /* needed for old kernels */
+    sparams.xfer_align = pcm->config.period_size / 2; /* needed for old kernels */
     sparams.silence_size = config->silence_size;
+    pcm->config.silence_size = config->silence_size;
     sparams.silence_threshold = config->silence_threshold;
+    pcm->config.silence_threshold = config->silence_threshold;
 
     if (pcm->ops->ioctl(pcm->data, SNDRV_PCM_IOCTL_SW_PARAMS, &sparams)) {
         int errno_copy = errno;

--- a/tests/src/pcm_out_test.cc
+++ b/tests/src/pcm_out_test.cc
@@ -103,6 +103,11 @@ TEST_F(PcmOutTest, SetConfig) {
     ASSERT_EQ(pcm_set_config(pcm_object, nullptr), 0);
 }
 
+TEST_F(PcmOutTest, SetSwConfig) {
+    ASSERT_EQ(pcm_set_sw_config(nullptr, nullptr), -EFAULT);
+    ASSERT_EQ(pcm_set_sw_config(pcm_object, &kDefaultConfig), 0);
+}
+
 TEST_F(PcmOutTest, GetBufferSize) {
     unsigned int buffer_size = pcm_get_buffer_size(pcm_object);
     ASSERT_EQ(buffer_size, kDefaultConfig.period_count * kDefaultConfig.period_size);


### PR DESCRIPTION
Unlike hardware configurations, software configurations can be modified at any time during stream operation. This change introduces `pcm_set_sw_config` to allow applications to dynamically update software parameters (such as start/stop thresholds and avail_min) at runtime without requiring a stream restart.

Key changes:
* Add public function `pcm_set_sw_config` to `pcm.h` and implement it in `pcm.c`, refactoring `pcm_set_config` to delegate software parameter configuration to it.
* Calculate default thresholds (`start_threshold`, `stop_threshold`, and `xfer_align`) using `pcm->config.period_size` and `pcm->config.period_count` (the refined hardware parameters negotiated with the driver) rather than raw user input.
* Evaluate `if (!config->avail_min)` against the user-provided configuration parameter to correctly determine when fallback defaults are required.
* Synchronize user-provided threshold and silence settings (`silence_threshold`, `silence_size`, `avail_min`, `start_threshold`, `stop_threshold`) into internal `pcm->config` state for consistent runtime state tracking.
* Update `pcm->mmap_control->avail_min` in user-space when `mmap_control` is allocated, preventing subsequent `pcm_sync_ptr` calls (e.g., during `pcm_get_htimestamp` in non-MMAP mode on ARM64) from overwriting the kernel's `avail_min` with an outdated value.
* Add unit test coverage for `pcm_set_sw_config` in `pcm_out_test.cc`.